### PR TITLE
解决synthetic tasks每次迭代选出样本点可能重复的情况，修复一定次数迭代后会卡在某一轮rollout情况

### DIFF
--- a/dante/deep_active_learning.py
+++ b/dante/deep_active_learning.py
@@ -1,12 +1,93 @@
 from dataclasses import dataclass, field
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any, Dict, Optional, Set, Tuple
+import time
 
 import numpy as np
+import matplotlib.pyplot as plt
 
 from dante.neural_surrogate import SurrogateModel
 from dante.obj_functions import ObjectiveFunction
 from dante.tree_exploration import TreeExploration
 from dante.utils import generate_initial_samples
+
+
+def _plot_global_min_value_trend(
+    iterations: list[int],
+    min_values: list[float],
+    output_path: Path,
+) -> None:
+    if not iterations or not min_values:
+        return
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+    ax.plot(iterations, min_values, marker="o", linestyle="-", color="#1f77b4")
+    ax.set_title("Global Minimum Value Trend")
+    ax.set_xlabel("Iteration")
+    ax.set_ylabel("Current Minimum True Value Found")
+    ax.grid(True)
+    if iterations:
+        f = max(1, len(iterations) // 20)
+        xticks = [it for idx, it in enumerate(iterations, start=1) if idx % f == 0 or it == iterations[-1]]
+        ax.set_xticks(xticks)
+
+    global_min = float("inf")
+    for iter_num, value in zip(iterations, min_values):
+        if value < global_min:
+            global_min = value
+            label_txt = f"{value:.2f}" if abs(value) < 1e3 else f"{value:.2e}"
+            ax.annotate(
+                label_txt,
+                (iter_num, value),
+                textcoords="offset points",
+                xytext=(0, 10),
+                ha="center",
+                fontsize=9,
+                bbox=dict(boxstyle="round,pad=0.3", fc="white", ec="gray", alpha=0.8),
+            )
+
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def _plot_best_samples_pearson(
+    iterations: list[int],
+    values: list[float],
+    output_path: Path,
+) -> None:
+    if not iterations or not values:
+        return
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    fig, ax = plt.subplots(figsize=(12, 7))
+    ax.plot(
+        iterations,
+        values,
+        marker="o",
+        linestyle="-",
+        color="#ff00ff",
+        linewidth=1.5,
+        markersize=4,
+        label="Pearson on Best Samples",
+    )
+    ax.set_title("Pearson Correlation on Best Samples")
+    ax.set_xlabel("Active Learning Iteration")
+    ax.set_ylabel("Pearson Correlation Coefficient")
+    ax.set_ylim(-1.05, 1.05)
+    ax.grid(True, alpha=0.3)
+    if iterations:
+        f = max(1, len(iterations) // 20)
+        xticks = [it for idx, it in enumerate(iterations, start=1) if idx % f == 0 or it == iterations[-1]]
+        ax.set_xticks(xticks)
+    ax.legend(loc="upper right")
+
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
 
 
 @dataclass
@@ -19,31 +100,197 @@ class DeepActiveLearning:
     num_samples_per_acquisition: int = 20
     input_x: np.ndarray = None
     input_scaled_y: np.ndarray = None
+    input_raw_y: Optional[np.ndarray] = None
 
     def __post_init__(self):
         assert self.num_data_acquisition > 0
         self.dims = self.func.dims
-        self.input_x, self.input_scaled_y = generate_initial_samples(
-            self.func, self.num_init_samples, apply_scaling=True
-        )
+        if self.input_x is None or self.input_scaled_y is None:
+            self.input_x, self.input_scaled_y = generate_initial_samples(
+                self.func, self.num_init_samples, apply_scaling=True
+            )
+        else:
+            assert len(self.input_x) == len(
+                self.input_scaled_y
+            ), "input_x 与 input_scaled_y 的长度必须一致"
+        self.input_x = np.asarray(self.input_x, dtype=np.float32)
+        self.input_scaled_y = np.asarray(self.input_scaled_y, dtype=np.float32).reshape(-1)
+        if self.input_raw_y is None:
+            self.input_raw_y = np.array(
+                [
+                    self.func(x, apply_scaling=False, track=False)
+                    for x in self.input_x
+                ],
+                dtype=np.float32,
+            )
+        else:
+            assert len(self.input_x) == len(
+                self.input_raw_y
+            ), "input_raw_y 长度必须与 input_x 保持一致"
+            self.input_raw_y = np.asarray(self.input_raw_y, dtype=np.float32).reshape(-1)
+        self._visited_nodes: Set[Tuple[float, ...]] = set()
 
     def run(self):
+        iteration_history: list[int] = []
+        global_min_history: list[float] = []
+        global_min_plot_path = Path(self.func.tracker.folder_name) / "global_min_value_trend.png"
+        best_samples_iterations: list[int] = []
+        best_samples_pearson_history: list[float] = []
+
         for i in range(self.num_data_acquisition // self.num_samples_per_acquisition):
+            iteration_start = time.perf_counter()
+            prev_best = getattr(self.func.tracker, "_current_best", float("inf"))
+            train_start = time.perf_counter()
             model = self.surrogate(self.input_x, self.input_scaled_y, verbose=True)
+            train_duration = time.perf_counter() - train_start
+            viz_duration = 0.0
+
+            viz_checkpoint = time.perf_counter()
+            pearson_best = self._compute_best_samples_pearson(model)
+            viz_duration += time.perf_counter() - viz_checkpoint
+            if pearson_best is not None:
+                iteration_idx = i + 1
+                best_samples_iterations.append(iteration_idx)
+                best_samples_pearson_history.append(pearson_best)
+                pearson_path = (
+                    Path(self.func.tracker.folder_name)
+                    / "best_samples_pearson_trend.png"
+                )
+                viz_checkpoint = time.perf_counter()
+                _plot_best_samples_pearson(
+                    best_samples_iterations,
+                    best_samples_pearson_history,
+                    pearson_path,
+                )
+                viz_duration += time.perf_counter() - viz_checkpoint
+
             tree_explorer = TreeExploration(
                 func=self.func,
                 model=model,
                 num_samples_per_acquisition=self.num_samples_per_acquisition,
+                visited_nodes=self._visited_nodes,
                 **self.tree_explorer_args,
             )
+            rollout_start = time.perf_counter()
             top_x = tree_explorer.rollout(
                 self.input_x,
                 self.input_scaled_y,
                 iteration=i,
             )
+            rollout_duration = time.perf_counter() - rollout_start
             top_y = np.array([self.func(x, apply_scaling=True) for x in top_x])
+            top_y_raw = np.array(
+                [self.func(x, apply_scaling=False, track=False) for x in top_x]
+            )
+            self._log_iteration(i + 1, top_x, top_y_raw, top_y)
             self.input_x = np.concatenate((self.input_x, top_x), axis=0)
             self.input_scaled_y = np.concatenate((self.input_scaled_y, top_y))
+            self.input_raw_y = np.concatenate((self.input_raw_y, top_y_raw))
 
+            new_best = getattr(self.func.tracker, "_current_best", prev_best)
+            generated_nodes = tree_explorer.get_generated_nodes()
+            if new_best < prev_best - 1e-12:
+                self._visited_nodes = set(generated_nodes)
+            else:
+                self._visited_nodes.update(generated_nodes)
+
+            current_best = float(np.min(self.input_raw_y)) if self.input_raw_y.size else None
+            if current_best is not None and np.isfinite(current_best):
+                iteration_idx = i + 1
+                iteration_history.append(iteration_idx)
+                global_min_history.append(current_best)
+                viz_checkpoint = time.perf_counter()
+                _plot_global_min_value_trend(
+                    iteration_history, global_min_history, global_min_plot_path
+                )
+                viz_duration += time.perf_counter() - viz_checkpoint
+
+                # 若为 Rosenbrock/Ackley，真值达到 0 则提前结束
+                _fname = getattr(self.func, "name", "").lower()
+                if _fname in ("rosenbrock", "ackley", "schwefel") and np.isclose(current_best, 0.0, atol=1e-12):
+                    print(f"[INFO] 触达 {_fname.capitalize()} 全局最优 (raw=0.0)，提前结束迭代。")
+                    break
+
+            total_duration = time.perf_counter() - iteration_start
+            print(
+                f"[Timing] Iteration {i + 1}: "
+                f"train={train_duration:.2f}s, "
+                f"rollout={rollout_duration:.2f}s, "
+                f"viz={viz_duration:.2f}s, "
+                f"total={total_duration:.2f}s"
+            )
             if np.isclose(self.input_scaled_y.min(), 0.0):
                 break
+
+    def _log_iteration(
+        self,
+        iteration: int,
+        top_x: np.ndarray,
+        top_y_raw: np.ndarray,
+        top_y_scaled: np.ndarray,
+    ) -> None:
+        print(
+            f"[Iteration {iteration}] Selected {len(top_x)} candidates "
+            "(raw and scaled objective values shown):"
+        )
+        for idx, (coords, raw_val, scaled_val) in enumerate(
+            zip(top_x, top_y_raw, top_y_scaled), start=1
+        ):
+            coords_str = np.array2string(
+                coords,
+                precision=4,
+                separator=", ",
+                suppress_small=True,
+            )
+            print(
+                f"  #{idx:02d} raw={raw_val:.6f}, scaled={scaled_val:.6f}, x={coords_str}"
+            )
+        best_val = getattr(self.func.tracker, "_current_best", None)
+        best_x = getattr(self.func.tracker, "_current_best_x", None)
+        if best_x is not None and best_val is not None and np.isfinite(best_val):
+            best_coords = np.array2string(
+                best_x,
+                precision=4,
+                separator=", ",
+                suppress_small=True,
+            )
+            print(
+                f"[Iteration {iteration}] Current best raw objective = {best_val:.6f}, "
+                f"x = {best_coords}"
+            )
+        else:
+            print(f"[Iteration {iteration}] Current best raw objective unavailable.")
+
+    def _compute_best_samples_pearson(self, model: SurrogateModel) -> Optional[float]:
+        if self.input_x is None or self.input_x.size == 0:
+            return None
+        if self.input_scaled_y is None or self.input_scaled_y.size == 0:
+            return None
+        if self.input_raw_y is None or self.input_raw_y.size == 0:
+            return None
+
+        try:
+            predictions = model.predict(
+                self.input_x.reshape(len(self.input_x), self.dims, 1), verbose=False
+            ).reshape(-1)
+        except Exception:
+            return None
+
+        true_scaled = self.input_scaled_y.reshape(-1)
+        raw_values = self.input_raw_y.reshape(-1)
+
+        top_k = min(60, len(raw_values))
+        if top_k < 2:
+            return 0.0
+
+        best_indices = np.argsort(raw_values)[:top_k]
+        subset_pred = predictions[best_indices]
+        subset_true = true_scaled[best_indices]
+
+        if subset_pred.size < 2 or subset_true.size < 2:
+            return 0.0
+
+        pearson = float(np.corrcoef(subset_pred, subset_true)[0, 1])
+        if np.isnan(pearson):
+            pearson = 0.0
+        return pearson

--- a/dante/neural_surrogate.py
+++ b/dante/neural_surrogate.py
@@ -7,14 +7,15 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path
+from typing import Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
-import seaborn as sns
-from scipy import stats
 from sklearn import metrics
+import gc
 from sklearn.model_selection import train_test_split
 from tensorflow import keras
+from tensorflow.keras import backend as K
 from tensorflow.keras import layers
 from tensorflow.keras.callbacks import EarlyStopping, ModelCheckpoint
 from tensorflow.keras.layers import (
@@ -52,7 +53,88 @@ class SurrogateModel(ABC):
     batch_size: int = 64
     epochs: int = 500
     patience: int = 30
+    log_interval: int = 50
+    plot_dir: Optional[Path] = None
     _model: keras.Model = None
+    _fit_call_count: int = field(init=False, default=0)
+
+    class _EpochProgressLogger(keras.callbacks.Callback):
+        def __init__(
+            self,
+            total_epochs: int,
+            log_every: int,
+            monitor: str,
+            checkpoint_path: Path,
+        ) -> None:
+            super().__init__()
+            self.total_epochs = total_epochs
+            self.log_every = max(1, log_every)
+            self.monitor = monitor
+            self.checkpoint_path = checkpoint_path
+            self.best = np.inf
+            self.last_logged_epoch = 0
+            self.last_epoch = 0
+            self.last_logs: dict[str, float] = {}
+            self.last_improved = False
+            self.last_previous_best = np.inf
+
+        def on_epoch_end(self, epoch: int, logs: Optional[dict[str, float]] = None) -> None:
+            logs = logs or {}
+            current_epoch = epoch + 1
+            current_monitor = logs.get(self.monitor)
+            previous_best = self.best
+            improved = False
+            if current_monitor is not None and current_monitor < self.best:
+                self.best = current_monitor
+                improved = True
+
+            self.last_epoch = current_epoch
+            self.last_logs = logs.copy()
+            self.last_improved = improved
+            self.last_previous_best = previous_best
+
+            if current_epoch % self.log_every == 0:
+                self._print_progress(current_epoch, logs, improved, previous_best)
+
+        def on_train_end(self, logs: Optional[dict[str, float]] = None) -> None:
+            if self.last_epoch and self.last_epoch != self.last_logged_epoch:
+                self._print_progress(
+                    self.last_epoch,
+                    self.last_logs,
+                    self.last_improved,
+                    self.last_previous_best,
+                )
+
+        def _print_progress(
+            self,
+            current_epoch: int,
+            logs: dict[str, float],
+            improved: bool,
+            previous_best: float,
+        ) -> None:
+            self.last_logged_epoch = current_epoch
+            loss = logs.get("loss")
+            val_loss = logs.get("val_loss")
+            loss_str = f"{loss:.5f}" if loss is not None else "NA"
+            val_loss_str = f"{val_loss:.5f}" if val_loss is not None else "NA"
+
+            if improved and val_loss is not None:
+                if np.isfinite(previous_best):
+                    print(
+                        f"Epoch {current_epoch}: {self.monitor} improved from "
+                        f"{previous_best:.5f} to {val_loss_str}, saving model to "
+                        f"{self.checkpoint_path}"
+                    )
+                else:
+                    print(
+                        f"Epoch {current_epoch}: {self.monitor} improved to "
+                        f"{val_loss_str}, saving model to {self.checkpoint_path}"
+                    )
+            else:
+                print(
+                    f"Epoch {current_epoch}/{self.total_epochs} - "
+                    f"loss: {loss_str} - {self.monitor}: {val_loss_str}"
+                )
 
     @abstractmethod
     def create_model(self) -> keras.Model:
@@ -82,6 +164,13 @@ class SurrogateModel(ABC):
         Returns:
             keras.Model: The trained Keras model.
         """
+        # 清理上一轮可能残留的计算图/句柄，避免内存逐轮增长
+        try:
+            K.clear_session()
+        except Exception:
+            pass
+        gc.collect()
+
         x_train, x_test, y_train, y_test = train_test_split(
             x,
             y,
@@ -95,58 +184,170 @@ class SurrogateModel(ABC):
             self.check_point_path,
             monitor="val_loss",
             mode="min",
-            verbose=verbose,
+            verbose=0,
             save_best_only=True,
         )
         early_stop = EarlyStopping(
             monitor="val_loss", patience=self.patience, restore_best_weights=True
         )
+        callbacks_list = [early_stop, mc]
+        if verbose:
+            progress_logger = self._EpochProgressLogger(
+                total_epochs=self.epochs,
+                log_every=self.log_interval,
+                monitor="val_loss",
+                checkpoint_path=self.check_point_path,
+            )
+            callbacks_list.append(progress_logger)
         self.model.fit(
             x_train.reshape(len(x_train), self.input_dims, 1),
             y_train,
             batch_size=self.batch_size,
             epochs=self.epochs,
             validation_data=(x_test.reshape(len(x_test), self.input_dims, 1), y_test),
-            callbacks=[early_stop, mc],
-            verbose=verbose,
+            callbacks=callbacks_list,
+            verbose=0,
         )
 
         self.model = keras.models.load_model(self.check_point_path)
-        y_pred = self.model.predict(
+
+        y_train_pred = self.model.predict(
+            x_train.reshape(len(x_train), self.input_dims, 1), verbose=verbose
+        ).reshape(-1)
+        y_test_pred = self.model.predict(
             x_test.reshape(len(x_test), self.input_dims, 1), verbose=verbose
+        ).reshape(-1)
+
+        self._fit_call_count += 1
+        self.evaluate_model(
+            y_train=y_train,
+            y_train_pred=y_train_pred,
+            y_test=y_test,
+            y_test_pred=y_test_pred,
+            iteration=self._fit_call_count,
         )
 
-        self.evaluate_model(y_test, y_pred)
-
+        # 主动触发一次垃圾回收，降低长期运行的内存峰值
+        gc.collect()
         return self.model
 
-    def evaluate_model(self, y_test, y_pred):
+    def evaluate_model(
+        self,
+        y_train: np.ndarray,
+        y_train_pred: np.ndarray,
+        y_test: np.ndarray,
+        y_test_pred: np.ndarray,
+        iteration: int,
+    ) -> None:
         """
         Evaluate the model's performance and plot results.
 
         This method calculates various performance metrics and creates a regression plot.
 
         Args:
-            y_test (np.ndarray): True target values.
-            y_pred (np.ndarray): Predicted target values.
+            y_train (np.ndarray): Training true values.
+            y_train_pred (np.ndarray): Training predictions.
+            y_test (np.ndarray): Test true values.
+            y_test_pred (np.ndarray): Test predictions.
         """
-        r = stats.pearsonr(y_pred.reshape(-1), y_test.reshape(-1))[0]
-        r = np.asarray(r).round(3)
-        r_squared = metrics.r2_score(y_test, y_pred)
-        mae = metrics.mean_absolute_error(y_test.reshape(-1), y_pred.reshape(-1))
-        mape = metrics.mean_absolute_percentage_error(
-            y_test.reshape(-1), y_pred.reshape(-1)
-        )
-        mae = np.asarray(mae).round(5)
-        mape = np.asarray(mape).round(5)
-        print(
-            f"Model performance: R2 {r_squared:.3f}, MAE {mae:.5f}, MAPE {mape:.5f}"
+        train_metrics = self._plot_predictions_vs_truth(
+            truth=y_train.reshape(-1),
+            predictions=y_train_pred.reshape(-1),
+            iteration=iteration,
+            title_suffix="(Train Set)",
+            filename=(
+                f"train_prediction_vs_truth_iter_{iteration:03d}.png"
+                if self.plot_dir is not None
+                else None
+            ),
         )
 
-        plt.figure()
-        sns.regplot(x=y_pred, y=y_test, color="k")
-        plt.xlabel("Predicted value")
-        plt.ylabel("Ground truth")
+        test_metrics = self._plot_predictions_vs_truth(
+            truth=y_test.reshape(-1),
+            predictions=y_test_pred.reshape(-1),
+            iteration=iteration,
+            title_suffix="(Test Set)",
+            filename=(
+                f"test_prediction_vs_truth_iter_{iteration:03d}.png"
+                if self.plot_dir is not None
+                else None
+            ),
+        )
+
+        if train_metrics is not None:
+            mse, rmse, mae, pearson = train_metrics
+            print(
+                f"Model train performance — MSE: {mse:.5f}, RMSE: {rmse:.5f}, MAE: {mae:.5f}, Pearson: {pearson:.4f}"
+            )
+
+        if test_metrics is not None:
+            mse, rmse, mae, pearson = test_metrics
+            r_squared = metrics.r2_score(y_test.reshape(-1), y_test_pred.reshape(-1))
+            mape = metrics.mean_absolute_percentage_error(
+                y_test.reshape(-1), y_test_pred.reshape(-1)
+            )
+            print(
+                f"Model test performance — R2: {r_squared:.3f}, MSE: {mse:.5f}, RMSE: {rmse:.5f}, MAE: {mae:.5f}, MAPE: {mape:.5f}, Pearson: {pearson:.4f}"
+            )
+
+    def _plot_predictions_vs_truth(
+        self,
+        truth: np.ndarray,
+        predictions: np.ndarray,
+        iteration: int,
+        title_suffix: str,
+        filename: Optional[str] = None,
+    ) -> Optional[tuple[float, float, float, float]]:
+        if truth.size == 0 or predictions.size == 0:
+            return None
+
+        mse = float(np.mean((predictions - truth) ** 2))
+        rmse = float(np.sqrt(mse))
+        mae = float(np.mean(np.abs(predictions - truth)))
+
+        if predictions.size >= 2 and truth.size >= 2:
+            pearson = float(np.corrcoef(predictions, truth)[0, 1])
+            if np.isnan(pearson):
+                pearson = 0.0
+        else:
+            pearson = 0.0
+
+        min_val = float(min(np.min(predictions), np.min(truth)))
+        max_val = float(max(np.max(predictions), np.max(truth)))
+
+        plt.figure(figsize=(10, 8))
+        plt.scatter(truth, predictions, color="#1f77b4", alpha=0.7)
+        plt.plot([min_val, max_val], [min_val, max_val], "r--", label="Ideal y=x line")
+
+        metrics_text = (
+            f"MSE: {mse:.4f}\nRMSE: {rmse:.4f}\nMAE: {mae:.4f}\nPearson: {pearson:.4f}"
+        )
+        plt.annotate(
+            metrics_text,
+            xy=(0.02, 0.95),
+            xycoords="axes fraction",
+            bbox=dict(boxstyle="round,pad=0.3", fc="white", ec="gray", alpha=0.8),
+            ha="left",
+            va="top",
+        )
+
+        title = f"Predictions vs. Ground Truth (Iteration {iteration})"
+        if title_suffix:
+            title = f"{title} {title_suffix}"
+        title = f"{title}\nMSE: {mse:.2f}, RMSE: {rmse:.2f}, Pearson: {pearson:.4f}"
+        plt.title(title)
+        plt.xlabel("True Values")
+        plt.ylabel("Model Predictions")
+        plt.grid(True, alpha=0.3)
+        plt.legend()
+
+        if filename and self.plot_dir is not None:
+            self.plot_dir.mkdir(parents=True, exist_ok=True)
+            save_path = self.plot_dir / filename
+            plt.savefig(save_path, dpi=150, bbox_inches="tight")
+
+        plt.close()
+        return mse, rmse, mae, pearson
 
 
 class AckleySurrogateModel(SurrogateModel):

--- a/dante/tree_exploration.py
+++ b/dante/tree_exploration.py
@@ -1,318 +1,462 @@
 import math
+import os
+import time
 import random
 from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
 from dataclasses import dataclass, field
-from typing import Any, Set, Optional, Dict, List
-
+from typing import Dict, List, Optional, Set, Tuple
 
 import keras
 import numpy as np
 
-from dante.obj_functions import ObjectiveFunction, BuiltInSyntheticFunction
+from dante.obj_functions import ObjectiveFunction
 
 
 @dataclass
 class TreeExploration:
-    func: ObjectiveFunction = None
-    model: keras.Model = None
-    N: Dict[Any, int] = field(default_factory=lambda: defaultdict(int))
-    children: Dict[Any, Set] = field(default_factory=dict)
-    rollout_round: int = 200
-    ratio: float = 0.02 # 0.02 is suit for 'rastrigin','ackley','griewank','schwefel'
+    func: ObjectiveFunction
+    model: keras.Model
     exploration_weight: float = 0.1
-    num_list: List[int] = field(default_factory=lambda: [5, 1, 1])
+    rollout_round: int = 200
+    ratio: float = 0.02
     num_samples_per_acquisition: int = 20
+    num_list: Tuple[int, int, int] = (5, 1, 1)
+    # 新增：每轮用作根节点的数量（仅非特殊函数，如 rosenbrock 等）
+    root_points: int = 3
+    # 新增：是否在每个 100 轮迭代的后 20% 衰减探索权重
+    attenuate_late: bool = True
+    N: Dict["OptTask", int] = field(init=False)
+    Q: Dict["OptTask", float] = field(init=False)
+    children: Dict["OptTask", Set["OptTask"]] = field(init=False)
+    unexpanded: Dict["OptTask", List["OptTask"]] = field(init=False)
+    visited_nodes: Optional[Set[Tuple[float, ...]]] = None
+    new_nodes: Set[Tuple[float, ...]] = field(init=False)
 
-    def choose(self, node):
-        """Choose the best successor of node."""
+    def __post_init__(self) -> None:
+        self._debug = os.getenv("DANTE_DEBUG_TIMING", "0") not in ("0", "", "false", "False")
+        self.N = defaultdict(int)
+        self.Q = defaultdict(float)
+        self.children = {}
+        self.unexpanded = {}
+        if self.visited_nodes is None:
+            self.visited_nodes = set()
+        self._initial_visited = set(self.visited_nodes)
+        self._local_seen: Set[Tuple[float, ...]] = set(self.visited_nodes)
+        self.new_nodes = set()
+        if self.func.name in {"rosenbrock", "schwefel"}:
+            self.num_list = (15, 3, 2)
+
+    def choose(self, node: "OptTask") -> Tuple["OptTask", List[Tuple[float, ...]]]:
         if node.is_terminal():
             raise RuntimeError(f"choose called on terminal node {node}")
 
-        log_N_vertex = math.log(self.N[node])
+        if node not in self.children or not self.children[node]:
+            self._expand(node)
+        if node not in self.children or not self.children[node]:
+            raise RuntimeError("No children available for expansion.")
 
-        def uct(n):
-            """Upper confidence bound for trees"""
-            return n.value + self.exploration_weight * math.sqrt(
-                log_N_vertex / (self.N[n] + 1)
-            )
+        log_n = math.log(self.N[node] + 1)
 
-        media_node = max(self.children[node], key=uct)
-        node_rand = [
-            list(self.children[node])[i].tup
-            for i in np.random.randint(0, len(self.children[node]), 2)
-        ]
-        # print('uct of root:',uct(node),'value of root:',node.value)
-        # print('uct of best leaf:',uct(media_node),'value of best leaf:',media_node.value)
+        def uct(n: "OptTask") -> float:
+            return n.value + self.exploration_weight * math.sqrt(log_n / (self.N[n] + 1))
 
-        return (
-            (media_node, node_rand)
-            if uct(media_node) > uct(node)
-            else (node, node_rand)
-        )
+        candidates = list(self.children[node])
+        best_child = max(candidates, key=uct)
+        rand_size = min(2, len(candidates))
+        rand_indices = np.random.choice(len(candidates), size=rand_size, replace=False)
+        random_nodes = [candidates[idx].tup for idx in rand_indices]
 
-    def do_rollout(self, node):
-        """Make the tree one layer better. (Train for one iteration.)"""
-        self._expand(node)
-        self._backpropagate(path=node)
+        if uct(best_child) > uct(node):
+            return best_child, random_nodes
+        return node, random_nodes
 
-    @staticmethod
-    def data_process(x: np.ndarray, boards: List[list]) -> np.ndarray:
-        new_x = []
-        boards = np.unique(np.array(boards), axis=0)
-        new_x = [board for board in boards if not np.any(np.all(board == x, axis=1))]
-        # print(f"Unique number of boards: {len(new_x)}")
-        return np.array(new_x)
+    def do_rollout(self, node: "OptTask") -> None:
+        path = self._select(node)
+        leaf = path[-1]
+        self._expand(leaf)
+        reward = self._simulate(leaf)
+        self._backpropagate(path, reward)
+
+    def data_process(self, x: np.ndarray, boards: List[List[float]]) -> np.ndarray:
+        if not boards:
+            return np.empty((0, x.shape[1]), dtype=float)
+        boards_array = np.unique(np.array(boards, dtype=float), axis=0)
+        new_points: List[np.ndarray] = []
+        for candidate in boards_array:
+            if np.any(np.all(np.isclose(x, candidate, atol=1e-8), axis=1)):
+                continue
+            tup = tuple(np.round(candidate, 6))
+            if tup in self._local_seen:
+                continue
+            new_points.append(candidate)
+            # 延后记录：仅在最终候选确定后再写入 _local_seen/new_nodes
+        return np.array(new_points, dtype=float) if new_points else np.empty((0, x.shape[1]), dtype=float)
 
     def most_visit_node(self, x: np.ndarray, top_n: int) -> np.ndarray:
-        """Find the most visited nodes."""
-        N_visit = self.N
-        childrens = [i for i in self.children]
-        children_N = []
-        X_top = []
-        for child in childrens:
-            child_tup = np.array(child.tup)
-            same = np.all(child_tup == x, axis=1)
-            has_true = any(same)
-            if not has_true:
-                children_N.append(N_visit[child])
-                X_top.append(child_tup)
-        children_N = np.array(children_N)
-        X_top = np.array(X_top)
-        ind = np.argpartition(children_N, -top_n)[-top_n:]
-        X_topN = X_top[ind]
-        return X_topN
+        candidates: List[np.ndarray] = []
+        visits: List[int] = []
+        for child, visit in self.N.items():
+            tup = np.array(child.tup, dtype=float)
+            if np.any(np.all(np.isclose(x, tup, atol=1e-8), axis=1)):
+                continue
+            tup_key = tuple(np.round(tup, 6))
+            if tup_key in self._local_seen:
+                continue
+            candidates.append(tup)
+            visits.append(visit)
+            # 延后记录到最终候选集合时再进行
+        if not candidates or top_n <= 0:
+            return np.empty((0, x.shape[1]), dtype=float)
+        visits = np.array(visits)
+        candidates = np.array(candidates)
+        indices = np.argpartition(visits, -top_n)[-top_n:]
+        return candidates[indices]
 
-    def single_rollout(self, X, board_uct, num_list: List[float]):
-        """Perform a single rollout."""
-        boards = []
-        boards_rand = []
-        for _ in range(0, self.rollout_round):
-            self.do_rollout(board_uct)
-            board_uct, board_rand = self.choose(board_uct)
-            boards.append(list(board_uct.tup))
-            boards_rand.append(list(board_rand))
+    def single_rollout(self, X: np.ndarray, board: "OptTask", num_list: Tuple[int, int, int]) -> np.ndarray:
+        boards: List[List[float]] = []
+        random_boards: List[List[Tuple[float, ...]]] = []
+        current = board
+        for step in range(self.rollout_round):
+            t0 = time.perf_counter()
+            self.do_rollout(current)
+            t1 = time.perf_counter()
+            current, random_nodes = self.choose(current)
+            t2 = time.perf_counter()
+            if self._debug and (t1 - t0 > 2.0 or t2 - t1 > 2.0):
+                print(
+                    f"[DEBUG] rollout step {step+1}/{self.rollout_round}: do_rollout={t1-t0:.2f}s, choose={t2-t1:.2f}s",
+                    flush=True,
+                )
+            boards.append(list(current.tup))
+            random_boards.append(random_nodes)
+            if (step + 1) % max(1, self.rollout_round // 5) == 0:
+                print(
+                    f"[TreeExploration] rollout progress "
+                    f"{step + 1}/{self.rollout_round} "
+                    f"(current value={current.value:.5f})"
+                )
 
-        # visit nodes
         X_most_visit = self.most_visit_node(X, num_list[1])
 
-        # highest pred value nodes and random nodes
         new_x = self.data_process(X, boards)
         try:
-            new_pred = self.model.predict(
-                np.array(new_x).reshape(len(new_x), -1, 1), verbose=False
-            )
+            new_pred = self.model.predict(new_x.reshape(len(new_x), -1, 1), verbose=False)
             new_pred = np.array(new_pred).reshape(len(new_x))
-        except:
-            pass
-        boards_rand = np.vstack(boards_rand)
-        new_rands = self.data_process(X, boards_rand)
-        top_n = num_list[0]
-        if len(new_x) >= top_n:
-            ind = np.argsort(new_pred)[-top_n:]
-            top_X = new_x[ind]
-            X_rand2 = [
-                new_rands[random.randint(0, len(new_rands) - 1)]
-                for i in range(num_list[2])
-            ]
-        elif len(new_x) == 0:
-            new_pred = self.model.predict(
-                np.array(new_rands).reshape(len(new_rands), -1, 1), verbose=False
+        except Exception:
+            new_pred = np.array([])
+
+        flat_random: List[List[float]] = [list(node) for nodes in random_boards for node in nodes]
+        new_random = self.data_process(X, flat_random)
+
+        top_n, _, extra = num_list
+        if len(new_x) >= top_n and len(new_x) > 0:
+            indices = np.argsort(new_pred)[-top_n:]
+            top_x = new_x[indices]
+            random_samples = [
+                new_random[random.randint(0, len(new_random) - 1)]
+                for _ in range(extra)
+            ] if len(new_random) else []
+            random_samples = np.array(random_samples, dtype=float) if random_samples else np.empty((0, X.shape[1]), dtype=float)
+        elif len(new_x) == 0 and len(new_random) > 0:
+            new_pred_random = self.model.predict(
+                new_random.reshape(len(new_random), -1, 1), verbose=False
             ).reshape(-1)
-            ind = np.argsort(new_pred)[-top_n:]
-            top_X = new_rands[ind]
-            X_rand2 = [
-                new_rands[random.randint(0, len(new_rands) - 1)]
-                for i in range(num_list[2])
+            indices = np.argsort(new_pred_random)[-top_n:]
+            top_x = new_random[indices]
+            random_samples = [
+                new_random[random.randint(0, len(new_random) - 1)]
+                for _ in range(extra)
             ]
+            random_samples = np.array(random_samples, dtype=float)
         else:
-            top_X = np.array(new_x)
-            num_random = num_list[0] + num_list[2] - len(top_X)
-            X_rand2 = [
-                new_rands[random.randint(0, len(new_rands) - 1)]
-                for i in range(num_random)
-            ]
-        try:
-            top_X = np.concatenate([X_most_visit, top_X, X_rand2])
-        except:
-            top_X = np.concatenate([X_most_visit, top_X])
+            top_x = new_x
+            need = top_n + extra - len(top_x)
+            random_samples = []
+            if len(new_random) > 0 and need > 0:
+                need = min(need, len(new_random))
+                random_samples = new_random[np.random.choice(len(new_random), size=need, replace=False)]
+            random_samples = np.array(random_samples, dtype=float) if len(random_samples) else np.empty((0, X.shape[1]), dtype=float)
 
-        return top_X
+        candidates = np.concatenate([X_most_visit, top_x, random_samples], axis=0)
+        if candidates.size == 0:
+            return np.empty((0, X.shape[1]), dtype=float)
+        candidates = np.unique(candidates, axis=0)
+        # 在此时才将最终候选写入“已见集合”，避免过早地抑制探索
+        for row in candidates:
+            self._record_node(tuple(np.round(row.reshape(-1), 6)))
+        return candidates
 
-    def rollout(
-        self,
-        x: np.ndarray,
-        y: np.ndarray,
-        iteration: int,
-    ) -> np.ndarray:
-        """Perform rollout based on the function type."""
-        if self.func.name == 'rosenbrock':
-            self.ratio = 0.1
-
-        if self.func.name in [
-            'rastrigin',
-            'levy',
-        ]:
-            return self._rollout_for_specific_functions(x, y)
-        else:
-            return self._rollout_for_other_functions(x, y, iteration)
-
-    def _rollout_for_specific_functions(
-        self,
-        x: np.ndarray,
-        y: np.ndarray,
-    ) -> np.ndarray:
-        index_max = np.argmax(y)
-        print(max(y))
-        initial_x = x[index_max, :]
-        values = float(
-            self.model.predict(initial_x.reshape(1, -1, 1), verbose=False).reshape(1)
-        )
-        board_uct = OptTask(tup=tuple(initial_x), value=values, terminal=False)
-        self.exploration_weight = self.ratio * abs(max(y))
-        num_list = (
-            [18, 2, 0]
-            if self.func.name == 'rastrigin'
-            else [15, 3, 2]
-        )
-        return self.single_rollout(x, board_uct, num_list=num_list)
-
-    def _rollout_for_other_functions(
-        self,
-        x: np.ndarray,
-        y: np.ndarray,
-        iteration: int,
-    ) -> np.ndarray:
-        self.rollout_round = 100
-        UCT_low = iteration % 100 >= 80
-        x_current_top = self._get_unique_top_points(x, y)
-        x_top = []
-        for initial_X in x_current_top:
-            values = float(
-                self.model.predict(
-                    initial_X.reshape(1, -1, 1), verbose=False
-                ).reshape(1)
+    def rollout(self, x: np.ndarray, y: np.ndarray, iteration: int) -> np.ndarray:
+        if self.func.name in {"rastrigin", "ackley", "levy"}:
+            index_max = int(np.argmax(y))
+            initial_x = x[index_max]
+            predicted = float(
+                self.model.predict(initial_x.reshape(1, -1, 1), verbose=False).reshape(1)
             )
-            exp_weight = self.ratio * abs(max(y))
-            if UCT_low:
-                exp_weight = self.ratio * 0.5 * abs(max(y))
-            self.exploration_weight = exp_weight
-            board_uct = OptTask(tup=tuple(initial_X), value=values, terminal=False)
-            x_top.append(self.single_rollout(x, board_uct, self.num_list))
-        return np.vstack(x_top)[: self.num_samples_per_acquisition]
+            board = OptTask(tuple(initial_x), predicted, False)
+            self.exploration_weight = self.ratio * abs(float(y.max()))
+            num_list = (18, 2, 0) if self.func.name == "rastrigin" else (15, 3, 2)
+            candidates = self.single_rollout(x, board, num_list)
+        else:
+            uct_low = self.attenuate_late and (iteration % 100 >= 80)
+            top_points = self._get_unique_top_points(x, y, k=max(1, int(self.root_points)))
+            collected: List[np.ndarray] = []
+            for candidate in top_points:
+                prediction = float(
+                    self.model.predict(candidate.reshape(1, -1, 1), verbose=False).reshape(1)
+                )
+                exp_weight = self.ratio * abs(float(y.max()))
+                if uct_low:
+                    exp_weight *= 0.5
+                self.exploration_weight = exp_weight
+                board = OptTask(tuple(candidate), prediction, False)
+                rollout_points = self.single_rollout(x, board, self.num_list)
+                collected.append(rollout_points)
+            candidates = np.vstack(collected) if collected else np.empty((0, x.shape[1]), dtype=float)
 
-    def _get_unique_top_points(self, X: np.ndarray, y: np.ndarray) -> np.ndarray:
-        ind = np.argsort(y)
-        x_current_top = X[ind[-3:]]
-        x_current_top = np.unique(x_current_top, axis=0)
-        i = -4
-        while len(x_current_top) < 3:
-            x_current_top = np.concatenate((x_current_top, X[ind[i]].reshape(1, -1)))
-            x_current_top = np.unique(x_current_top, axis=0)
-            i -= 1
-        return x_current_top
+        if candidates.size == 0:
+            return np.empty((0, x.shape[1]), dtype=float)
+        unique_candidates = np.unique(candidates, axis=0)
+        if len(unique_candidates) > self.num_samples_per_acquisition:
+            indices = np.random.choice(
+                len(unique_candidates), size=self.num_samples_per_acquisition, replace=False
+            )
+            unique_candidates = unique_candidates[indices]
+        elif len(unique_candidates) < self.num_samples_per_acquisition:
+            needed = self.num_samples_per_acquisition - len(unique_candidates)
+            filler = self._sample_random_points(np.vstack([x, unique_candidates]), needed)
+            if filler.size:
+                unique_candidates = np.vstack([unique_candidates, filler])
+        return unique_candidates
 
-    def _expand(self, node):
-        """Update the `children` dict with the children of `node`"""
+    def _get_unique_top_points(self, X: np.ndarray, y: np.ndarray, k: int = 3) -> np.ndarray:
+        """从整体数据中选取按 y 排序最高的 k 个互不重复的点。
+
+        若存在重复坐标，将继续向下取，直到满足 k 个或数据耗尽。
+        """
+        indices = np.argsort(y)
+        want = max(1, int(k))
+        # 先取最后 want 个（最高）
+        current = np.unique(X[indices[-want:]], axis=0)
+        offset = want + 1
+        while len(current) < want and offset <= len(indices):
+            candidate = X[indices[-offset]].reshape(1, -1)
+            current = np.unique(np.concatenate([current, candidate], axis=0), axis=0)
+            offset += 1
+        return current
+
+    def _select(self, node: "OptTask") -> List["OptTask"]:
+        path: List["OptTask"] = []
+        # 用坐标追踪选择路径，防止在已展开子图中循环不返
+        seen_tups: Set[Tuple[float, ...]] = set()
+        while True:
+            path.append(node)
+            seen_tups.add(tuple(np.round(np.array(node.tup, dtype=float), 6)))
+            if node not in self.children or not self.children[node]:
+                return path
+            pending = self.unexpanded.get(node)
+            if pending:
+                while pending:
+                    candidate = pending.pop()
+                    if candidate not in self.children:
+                        path.append(candidate)
+                        return path
+            # 正常 UCT 选择
+            next_node = self._uct_select(node)
+            # 检测环：若返回到已见坐标，尝试选择一个未见过的候选；若没有则提前返回当前路径
+            cand_seen_key = tuple(np.round(np.array(next_node.tup, dtype=float), 6))
+            if cand_seen_key in seen_tups:
+                # 选择一个未出现过的子节点作为替代
+                alt = None
+                for cand in self.children[node]:
+                    key = tuple(np.round(np.array(cand.tup, dtype=float), 6))
+                    if key not in seen_tups:
+                        alt = cand
+                        break
+                if alt is None:
+                    # 无可选替代，返回当前路径作为叶子，交由上层进行扩展/回传
+                    if self._debug:
+                        print("[DEBUG] _select detected cycle; returning current path", flush=True)
+                    return path
+                next_node = alt
+            node = next_node
+
+    def _expand(self, node: "OptTask") -> None:
+        if node in self.children:
+            return
         action = list(range(len(node.tup)))
-        self.children[node] = node.find_children(
-            node, action, self.func, self.model
-        )
+        t0 = time.perf_counter()
+        children_set = OptTask.find_children(node, action, self.func, self.model)
+        t1 = time.perf_counter()
+        if self._debug and (t1 - t0 > 2.0):
+            print(
+                f"[DEBUG] _expand predict {len(children_set)} children took {t1 - t0:.2f}s",
+                flush=True,
+            )
+        # 过滤掉与自身坐标相同的子节点，进一步降低自环概率
+        children_set = {c for c in children_set if c.tup != node.tup}
+        self.children[node] = children_set
+        self.unexpanded[node] = [child for child in children_set if child not in self.children]
 
-    def _backpropagate(self, path):
-        """Send the reward back up to the ancestors of the leaf"""
-        self.N[path] += 1
+    def _simulate(self, node: "OptTask") -> float:
+        return node.reward(self.model)
+
+    def _backpropagate(self, path: List["OptTask"], reward: float) -> None:
+        for node in reversed(path):
+            self.N[node] += 1
+            self.Q[node] += reward
+
+    def _uct_select(self, node: "OptTask") -> "OptTask":
+        log_n = math.log(self.N[node] + 1)
+
+        def uct(n: "OptTask") -> float:
+            return n.value + self.exploration_weight * math.sqrt(log_n / (self.N[n] + 1))
+
+        return max(self.children[node], key=uct)
+
+    def _sample_random_points(self, existing: np.ndarray, count: int) -> np.ndarray:
+        if count <= 0:
+            return np.empty((0, existing.shape[1]), dtype=float)
+
+        lb, ub = self.func.lb[0], self.func.ub[0]
+        step = self.func.turn
+        grid = np.arange(lb, ub + step, step).round(5)
+
+        samples: List[np.ndarray] = []
+        attempts = 0
+        max_attempts = max(100, count * 50)
+
+        def is_duplicate(arr: np.ndarray, point: np.ndarray) -> bool:
+            if arr.size == 0:
+                return False
+            arr_flat = arr.reshape(arr.shape[0], -1)
+            point_flat = point.reshape(-1)
+            return np.any(np.all(np.isclose(arr_flat, point_flat, atol=1e-8), axis=1))
+
+        all_existing = existing.copy()
+        while len(samples) < count and attempts < max_attempts:
+            candidate = np.random.choice(grid, size=self.func.dims).astype(float)
+            candidate = candidate.reshape(1, -1)
+            tup_key = tuple(np.round(candidate.reshape(-1), 6))
+            if tup_key in self._local_seen:
+                attempts += 1
+                continue
+            if not is_duplicate(all_existing, candidate):
+                samples.append(candidate.reshape(-1))
+                all_existing = np.vstack([all_existing, candidate])
+                self._record_node(tup_key)
+            attempts += 1
+
+        if not samples:
+            return np.empty((0, existing.shape[1]), dtype=float)
+
+        return np.array(samples, dtype=float)
+
+    def _record_node(self, tup: Tuple[float, ...]) -> None:
+        if tup not in self._local_seen:
+            self._local_seen.add(tup)
+        if tup not in self._initial_visited:
+            self.new_nodes.add(tup)
+
+    def get_generated_nodes(self) -> Set[Tuple[float, ...]]:
+        return set(self.new_nodes)
+
+
+_OptTaskBase = namedtuple("OptTaskBase", "tup value terminal")
 
 
 class Node(ABC):
-    """
-    A representation of a single board state.
-    DOTS works by constructing a tree of these Nodes.
-    Could be e.g. a chess or checkers board state.
-    """
+    """Abstract node definition used by the tree search."""
 
     @abstractmethod
-    def find_children(self):
-        """All possible successors of this board state"""
-        return set()
+    def find_children(self) -> Set["Node"]:
+        """Return all possible successor nodes."""
 
     @abstractmethod
-    def is_terminal(self):
-        """Returns True if the node has no children"""
-        return True
+    def is_terminal(self) -> bool:
+        """Return True if the node has no children."""
 
     @abstractmethod
-    def __hash__(self):
-        """Nodes must be hashable"""
-        return 123456789
+    def reward(self, model: keras.Model) -> float:
+        """Return the reward associated with this node."""
 
     @abstractmethod
-    def __eq__(self, node2):
-        """Nodes must be comparable"""
-        return True
+    def __hash__(self) -> int:
+        """Nodes must be hashable."""
+
+    @abstractmethod
+    def __eq__(self, other: "Node") -> bool:
+        """Nodes must be comparable."""
 
 
-_OT = namedtuple("OptTask", "tup value terminal")
-
-
-class OptTask(_OT, Node):
+class OptTask(_OptTaskBase, Node):
     """Represents an optimization task node in the search tree."""
 
-    @staticmethod
-    def find_children(board, action, func, model):
-        """Find all possible child nodes for the current board state."""
-        if board.terminal:
-            return set()
+    # 关键修复：以坐标 tup 作为节点唯一性判定，避免相同坐标被当作不同节点
+    # 这可防止选择阶段在已完全展开的子图中产生环路而无法返回。
+    def __hash__(self) -> int:  # type: ignore[override]
+        return hash(self.tup)
 
-        all_tuples = OptTask._generate_child_tuples(board, action, func)
-        all_values = model.predict(
-            np.array(all_tuples).reshape(len(all_tuples), func.dims, 1), verbose=False
-        )
-
-        return {OptTask(tuple(t), v[0], False) for t, v in zip(all_tuples, all_values)}
+    def __eq__(self, other: "Node") -> bool:  # type: ignore[override]
+        try:
+            return isinstance(other, OptTask) and self.tup == other.tup
+        except Exception:
+            return False
 
     @staticmethod
-    def _generate_child_tuples(board, action, func):
-        """Generate child tuples based on the current board state and function parameters."""
-        turn = func.turn
-        possible_values = np.arange(
-            func.lb[0], func.ub[0] + func.turn, func.turn
-        ).round(5)
-        all_tuples = []
-
-        for index in action:
-            tup = list(board.tup)
-            OptTask._apply_random_modification(
-                tup, index, turn, possible_values, func.dims
-            )
-            tup = OptTask._clip_to_bounds(np.array(tup), func.lb[0], func.ub[0])
-            all_tuples.append(tup)
-
-        return all_tuples
-
-    @staticmethod
-    def _apply_random_modification(tup, index, turn, possible_values, dims):
-        """Apply a random modification to the tuple."""
+    def _random_mutation(
+        tup: List[float], index: int, turn: float, candidates: np.ndarray, dims: int
+    ) -> None:
         flip = random.randint(0, 5)
         if flip == 0:
             tup[index] += turn
         elif flip == 1:
             tup[index] -= turn
         elif flip in (2, 3):
-            num_changes = int(dims / 5) if flip == 2 else int(dims / 10)
-            for _ in range(num_changes):
-                random_index = random.randint(0, len(tup) - 1)
-                tup[random_index] = np.random.choice(possible_values)
+            count = int(dims / 5) if flip == 2 else int(dims / 10)
+            for _ in range(max(1, count)):
+                idx = random.randint(0, dims - 1)
+                tup[idx] = float(np.random.choice(candidates))
         elif flip in (4, 5):
-            tup[index] = np.random.choice(possible_values)
-
+            tup[index] = float(np.random.choice(candidates))
         tup[index] = round(tup[index], 5)
 
-    @staticmethod
-    def _clip_to_bounds(tup, lower_bound, upper_bound):
-        """Clip the tuple values to the given bounds."""
-        return np.clip(tup, lower_bound, upper_bound)
+    @classmethod
+    def _clip(cls, tup: np.ndarray, lb: float, ub: float) -> np.ndarray:
+        return np.clip(tup, lb, ub)
 
-    def is_terminal(self):
-        """Check if the current board state is terminal."""
+    @classmethod
+    def _child_tuples(
+        cls, board: "OptTask", action: List[int], func: ObjectiveFunction
+    ) -> List[np.ndarray]:
+        turn = func.turn
+        values = np.arange(func.lb[0], func.ub[0] + func.turn, func.turn).round(5)
+        children = []
+        for index in action:
+            candidate = list(board.tup)
+            cls._random_mutation(candidate, index, turn, values, func.dims)
+            candidate = cls._clip(np.array(candidate, dtype=float), func.lb[0], func.ub[0])
+            children.append(candidate)
+        return children
+
+    @staticmethod
+    def find_children(
+        board: "OptTask", action: List[int], func: ObjectiveFunction, model: keras.Model
+    ) -> Set["OptTask"]:
+        if board.terminal:
+            return set()
+        tuples = OptTask._child_tuples(board, action, func)
+        predictions = model.predict(
+            np.array(tuples, dtype=float).reshape(len(tuples), func.dims, 1), verbose=False
+        )
+        return {OptTask(tuple(t), float(v[0]), False) for t, v in zip(tuples, predictions)}
+
+    def reward(self, model: keras.Model) -> float:
+        prediction = model.predict(
+            np.array(self.tup, dtype=float).reshape(1, -1, 1), verbose=False
+        )
+        return float(np.asarray(prediction).reshape(-1)[0])
+
+    def is_terminal(self) -> bool:
         return self.terminal

--- a/dante/utils.py
+++ b/dante/utils.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Optional, TYPE_CHECKING
 
 import numpy as np
+import warnings
 
 if TYPE_CHECKING:
     from dante.obj_functions import ObjectiveFunction
@@ -20,6 +21,7 @@ class Tracker:
     _x_values: list[Optional[np.ndarray]] = field(init=False, default_factory=list)
     _current_best: float = field(init=False, default=float("inf"))
     _current_best_x: Optional[np.ndarray] = field(init=False, default=None)
+    log_frequency: Optional[int] = field(default=None)
 
     def __post_init__(self):
         """Initialize the tracker and create the folder after instance creation."""
@@ -55,12 +57,21 @@ class Tracker:
             self._current_best = result
             self._current_best_x = x
 
-        self._print_status()
         self._results.append(self._current_best)
         self._x_values.append(x)
 
         if save or self._counter % 20 == 0 or round(self._current_best, 5) == 0:
             self.dump_trace()
+
+        should_log = False
+        if self.log_frequency is not None and self.log_frequency > 0:
+            should_log = (
+                save
+                or self._counter % self.log_frequency == 0
+                or round(self._current_best, 5) == 0
+            )
+        if should_log:
+            self._print_status()
 
     def _print_status(self) -> None:
         """Print the current status of the optimization."""
@@ -75,6 +86,7 @@ def generate_initial_samples(
     objective_function: ObjectiveFunction,
     num_init_samples: int = 200,
     apply_scaling: bool = False,
+    **kwargs,
 ) -> tuple[np.ndarray, np.ndarray]:
     """
     Generate initial random samples for the given objective function.
@@ -89,6 +101,16 @@ def generate_initial_samples(
             input_samples (np.ndarray): Array of input points.
             output_values (float): Function output value.
     """
+    if "num_initial_sample" in kwargs:
+        warnings.warn(
+            "参数名 num_initial_sample 已废弃，请使用 num_init_samples；"
+            "此次调用将按 num_initial_sample 取值执行。",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if kwargs["num_initial_sample"] is not None:
+            num_init_samples = kwargs["num_initial_sample"]
+
     assert num_init_samples > 0, "sample_count must be positive"
 
     dimension_count = objective_function.dims

--- a/experiments/ackley_20d_opt.py
+++ b/experiments/ackley_20d_opt.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python
+"""
+使用与 Rosenbrock-20d 相同的优化与可视化流程，对 data_raw/Ackley-20d 进行主动优化。
+
+运行示例：
+    PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
+    python -u experiments/ackley_20d_opt.py \
+        --data-dir data_raw/Ackley-20d \
+        --acquisitions 8000 \
+        --samples-per-acquisition 20 \
+        --epochs 400
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import signal
+import faulthandler
+from datetime import datetime
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Tuple, List
+
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.metrics import mean_absolute_error, r2_score
+from sklearn.manifold import TSNE
+
+from dante.deep_active_learning import DeepActiveLearning
+from dante.neural_surrogate import AckleySurrogateModel
+from dante.obj_functions import Ackley
+
+
+# Enable faulthandler and register SIGUSR1 to dump stacks without terminating.
+try:
+    if not faulthandler.is_enabled():
+        faulthandler.enable()
+    faulthandler.register(signal.SIGUSR1, all_threads=True, chain=False)
+except Exception:
+    pass
+
+
+def _scale_values(func: Ackley, y_raw: np.ndarray) -> np.ndarray:
+    """将 Ackley 原始目标值映射到最大化的缩放值。"""
+    return np.array([func.scaled(float(val)) for val in y_raw], dtype=np.float32)
+
+
+def _load_dataset(data_dir: Path) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """读取离线数据集。"""
+    x_train = np.load(data_dir / "Ackley_x_train.npy").astype(np.float32)
+    y_train = np.load(data_dir / "Ackley_y_train.npy").astype(np.float32)
+    x_test = np.load(data_dir / "Ackley_x_test.npy").astype(np.float32)
+    y_test = np.load(data_dir / "Ackley_y_test.npy").astype(np.float32)
+    return x_train, y_train, x_test, y_test
+
+
+@dataclass
+class ExperimentConfig:
+    data_dir: Path
+    seed: int = 0
+    init_size: int = 200
+    acquisitions: int = 200
+    samples_per_acquisition: int = 20
+    epochs: int = 200
+    batch_size: int = 128
+    learning_rate: float = 1e-3
+    exploration_weight: float = 0.1
+    rollout_round: int = 50
+    ratio: float = 0.1
+    verbose: bool = False
+    turn: float = 0.1
+    nte_roots: int = 3
+    attenuate_late: bool = True
+
+
+def run_experiment(cfg: ExperimentConfig) -> None:
+    data_dir = cfg.data_dir
+
+    if not data_dir.exists():
+        raise FileNotFoundError(f"数据目录 {data_dir} 不存在")
+
+    x_train_raw, y_train_raw, x_test_raw, y_test_raw = _load_dataset(data_dir)
+
+    ackley = Ackley(dims=x_train_raw.shape[1], turn=cfg.turn)
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    run_dir = Path("ackley20") / timestamp
+    run_dir.mkdir(parents=True, exist_ok=True)
+    ackley.tracker.folder_name = str(run_dir)
+    Path(ackley.tracker.folder_name).mkdir(parents=True, exist_ok=True)
+    print(f"[INFO] 本次运行的可视化输出目录：{run_dir}")
+
+    # 训练集与测试集都转换为 surrogate 需要的缩放目标（越大越好）
+    y_train_scaled = _scale_values(ackley, y_train_raw)
+    y_test_scaled = _scale_values(ackley, y_test_raw)
+
+    init_x = x_train_raw
+    init_y_scaled = y_train_scaled
+
+    # 更新 tracker，使得初始最优值与坐标立即可用（使用真实目标值）
+    init_y_raw = []
+    for x_val in init_x:
+        raw_val = ackley(x_val, apply_scaling=False, track=True)
+        init_y_raw.append(raw_val)
+    init_y_raw = np.array(init_y_raw, dtype=np.float32)
+    initial_best_idx = int(np.argmin(init_y_raw))
+    print(
+        "[INFO] 初始数据最优解: "
+        f"f(x) = {init_y_raw[initial_best_idx]:.6f}, "
+        f"x = {np.array2string(init_x[initial_best_idx], precision=4, separator=', ', suppress_small=True)}"
+    )
+
+    surrogate = AckleySurrogateModel(
+        input_dims=init_x.shape[1],
+        epochs=cfg.epochs,
+        batch_size=cfg.batch_size,
+        learning_rate=cfg.learning_rate,
+    )
+    surrogate_plot_dir = run_dir / "surrogate_regression"
+    surrogate.plot_dir = surrogate_plot_dir
+    checkpoint_dir = Path.home() / ".cache" / "dante" / "checkpoints"
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    surrogate.check_point_path = checkpoint_dir / "ackley20_best.keras"
+
+    # save run configuration
+    tree_args = {
+        "exploration_weight": cfg.exploration_weight,
+        "rollout_round": cfg.rollout_round,
+        "ratio": cfg.ratio,
+        "root_points": cfg.nte_roots,
+        "attenuate_late": cfg.attenuate_late,
+    }
+    _write_run_config(run_dir, cfg, tree_args)
+
+    dal = DeepActiveLearning(
+        func=ackley,
+        num_data_acquisition=cfg.acquisitions,
+        surrogate=surrogate,
+        tree_explorer_args=tree_args,
+        num_samples_per_acquisition=cfg.samples_per_acquisition,
+        num_init_samples=len(init_x),
+        input_x=init_x,
+        input_scaled_y=init_y_scaled,
+        input_raw_y=init_y_raw,
+    )
+
+    print(
+        f"[INFO] 启动优化：初始样本 {len(init_x)}（使用全部训练数据），"
+        f"计划新增 {cfg.acquisitions} 条，每轮获取 {cfg.samples_per_acquisition} 条。"
+    )
+    dal.run()
+
+    final_x = dal.input_x
+    final_scaled = dal.input_scaled_y
+    final_raw = np.array(
+        [ackley(x, apply_scaling=False, track=False) for x in final_x],
+        dtype=np.float32,
+    )
+
+    best_idx = int(np.argmin(final_raw))
+    print(
+        "[RESULT] 当前最优："
+        f"f(x) = {final_raw[best_idx]:.6f}，"
+        f"scale = {final_scaled[best_idx]:.6f}，"
+        f"样本总数 {len(final_raw)}"
+    )
+
+    ackley.tracker.dump_trace()
+
+    results = np.array(ackley.tracker._results, dtype=np.float64)
+    if results.size:
+        np.save(run_dir / "best_trace.npy", results)
+        fig, ax = plt.subplots()
+        ax.plot(results)
+        ax.set_title("Best objective over iterations")
+        ax.set_xlabel("Iteration")
+        ax.set_ylabel("Best f(x)")
+        fig.savefig(run_dir / "best_trace.png", dpi=150, bbox_inches="tight")
+        plt.close(fig)
+
+    if final_x.size:
+        try:
+            initial_count = len(init_x)
+            offset = np.ones_like(final_x[:1])
+            tsne_input = final_x + offset if offset.size else final_x
+            perplexity = max(1, min(30, tsne_input.shape[0] - 1))
+            if tsne_input.shape[0] > 1 and perplexity > 0:
+                embedding = TSNE(
+                    n_components=2,
+                    learning_rate="auto",
+                    init="random",
+                    perplexity=perplexity,
+                ).fit_transform(tsne_input)
+                fig, ax = plt.subplots()
+                ax.scatter(
+                    embedding[:initial_count, 0],
+                    embedding[:initial_count, 1],
+                    s=6,
+                    c="tab:blue",
+                    label="Initial data",
+                )
+                if embedding.shape[0] > initial_count:
+                    ax.scatter(
+                        embedding[initial_count:, 0],
+                        embedding[initial_count:, 1],
+                        s=6,
+                        c="tab:red",
+                        label="Acquired data",
+                    )
+                best_idx = int(np.argmin(final_raw))
+                ax.scatter(
+                    embedding[best_idx, 0],
+                    embedding[best_idx, 1],
+                    marker="*",
+                    s=120,
+                    c="gold",
+                    label="Current best",
+                )
+                ax.set_title("t-SNE of sampled points")
+                ax.legend(loc="best")
+                fig.savefig(run_dir / "tsne_samples.png", dpi=150, bbox_inches="tight")
+                plt.close(fig)
+        except Exception as exc:
+            print(f"[WARN] Failed to generate t-SNE visualization: {exc}")
+
+    # 使用最终 surrogate 在离线测试集上评估表现
+    model = surrogate.model
+    if model is None:
+        print("[WARN] surrogate 尚未训练成功，跳过测试集评估。")
+        return
+
+    y_test_pred_scaled = model.predict(
+        x_test_raw.reshape(len(x_test_raw), init_x.shape[1], 1),
+        verbose=int(cfg.verbose),
+    ).reshape(-1)
+
+    r2 = r2_score(y_test_scaled, y_test_pred_scaled)
+    mae = mean_absolute_error(y_test_scaled, y_test_pred_scaled)
+    print(f"[TEST] Scaled 目标: R2={r2:.4f}, MAE={mae:.4f}")
+
+    # 将预测值反变换回原始目标，便于对比（Ackley: scaled=100/(y+0.01)）
+    epsilon = 1e-8
+    inv_pred_raw = 100 / np.clip(y_test_pred_scaled, epsilon, None) - 0.01
+    print(
+        "[TEST] 原始目标: MAE="
+        f"{mean_absolute_error(y_test_raw, inv_pred_raw):.4f}"
+    )
+
+
+def _write_run_config(run_dir: Path, cfg: "ExperimentConfig", tree_args: dict) -> None:
+    env_keys: List[str] = [
+        "OMP_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+        "TF_NUM_INTRAOP_THREADS",
+        "TF_NUM_INTEROP_THREADS",
+        "TF_FORCE_GPU_ALLOW_GROWTH",
+        "PYTHONFAULTHANDLER",
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD",
+        "PYTHONUNBUFFERED",
+        "DANTE_DEBUG_TIMING",
+        "CUDA_VISIBLE_DEVICES",
+    ]
+    lines: List[str] = []
+    lines.append("# DANTE run configuration\n")
+    lines.append(f"script = {Path(__file__).name}\n")
+    lines.append("[cli]")
+    for k, v in vars(cfg).items():
+        lines.append(f"{k} = {v}")
+    lines.append("")
+    lines.append("[tree_explorer_args]")
+    for k, v in tree_args.items():
+        lines.append(f"{k} = {v}")
+    lines.append("")
+    lines.append("[env]")
+    for k in env_keys:
+        lines.append(f"{k} = {os.getenv(k, '')}")
+    try:
+        (run_dir / "run_config.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    except Exception as exc:
+        print(f"[WARN] Failed to write run_config.txt: {exc}")
+
+
+def parse_args() -> ExperimentConfig:
+    parser = argparse.ArgumentParser(description="优化 Ackley-20d 数据集")
+    parser.add_argument("--data-dir", type=Path, default=Path("data_raw/Ackley-20d"))
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--init-size", type=int, default=200)
+    parser.add_argument("--acquisitions", type=int, default=200)
+    parser.add_argument("--samples-per-acquisition", type=int, default=20)
+    parser.add_argument("--epochs", type=int, default=200)
+    parser.add_argument("--batch-size", type=int, default=128)
+    parser.add_argument("--learning-rate", type=float, default=1e-3)
+    parser.add_argument("--exploration-weight", type=float, default=0.1)
+    parser.add_argument("--rollout-round", type=int, default=50)
+    parser.add_argument("--ratio", type=float, default=0.1)
+    parser.add_argument("--turn", type=float, default=0.1)
+    parser.add_argument("--nte-roots", type=int, default=3, help="每轮用于 NTE 的根节点个数（默认 3）")
+    parser.add_argument("--no-late-attenuation", action="store_true", help="关闭每 100 轮后 20% 的探索权重衰减")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+    cfg_kwargs = vars(args)
+    cfg_kwargs["attenuate_late"] = not args.no_late_attenuation
+    del cfg_kwargs["no_late_attenuation"]
+    return ExperimentConfig(**cfg_kwargs)
+
+
+if __name__ == "__main__":
+    config = parse_args()
+    run_experiment(config)

--- a/experiments/rosenbrock_20d_opt.py
+++ b/experiments/rosenbrock_20d_opt.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python
+"""
+使用 Rosenbrock-40d 同款 CNN 代理，对 data_raw/Rosenbrock-20d 数据进行主动优化。
+
+运行示例：
+    PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
+    python experiments/rosenbrock_20d_opt.py \
+        --data-dir data_raw/Rosenbrock-20d \
+        --init-size 200 \
+        --acquisitions 200 \
+        --epochs 200
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import signal
+import faulthandler
+from datetime import datetime
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Tuple, List
+
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.metrics import mean_absolute_error, r2_score
+from sklearn.manifold import TSNE
+
+from dante.deep_active_learning import DeepActiveLearning
+from dante.neural_surrogate import RosenbrockSurrogateModel
+from dante.obj_functions import Rosenbrock
+
+
+# Enable faulthandler and register SIGUSR1 to dump stacks without terminating.
+try:
+    if not faulthandler.is_enabled():
+        faulthandler.enable()  # dump tracebacks to stderr on fatal errors
+    # When receiving SIGUSR1, print stacks of all threads and continue.
+    # chain=False prevents default SIGUSR1 action (terminate).
+    faulthandler.register(signal.SIGUSR1, all_threads=True, chain=False)
+except Exception:
+    # Best-effort; continue even if registration fails in some environments.
+    pass
+
+
+def _scale_values(func: Rosenbrock, y_raw: np.ndarray) -> np.ndarray:
+    """按照 Rosenbrock 的缩放公式将目标值转换为最大化形式。"""
+    return np.array([func.scaled(float(val)) for val in y_raw], dtype=np.float32)
+
+
+def _load_dataset(data_dir: Path) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """读取离线数据集。"""
+    x_train = np.load(data_dir / "Rosenbrock_x_train.npy").astype(np.float32)
+    y_train = np.load(data_dir / "Rosenbrock_y_train.npy").astype(np.float32)
+    x_test = np.load(data_dir / "Rosenbrock_x_test.npy").astype(np.float32)
+    y_test = np.load(data_dir / "Rosenbrock_y_test.npy").astype(np.float32)
+    return x_train, y_train, x_test, y_test
+
+
+def _write_run_config(run_dir: Path, cfg: "ExperimentConfig", tree_args: dict) -> None:
+    env_keys: List[str] = [
+        "OMP_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+        "TF_NUM_INTRAOP_THREADS",
+        "TF_NUM_INTEROP_THREADS",
+        "TF_FORCE_GPU_ALLOW_GROWTH",
+        "PYTHONFAULTHANDLER",
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD",
+        "PYTHONUNBUFFERED",
+        "DANTE_DEBUG_TIMING",
+        "CUDA_VISIBLE_DEVICES",
+    ]
+    lines: List[str] = []
+    lines.append("# DANTE run configuration\n")
+    lines.append(f"script = {Path(__file__).name}\n")
+    lines.append("[cli]")
+    for k, v in vars(cfg).items():
+        lines.append(f"{k} = {v}")
+    lines.append("")
+    lines.append("[tree_explorer_args]")
+    for k, v in tree_args.items():
+        lines.append(f"{k} = {v}")
+    lines.append("")
+    lines.append("[env]")
+    for k in env_keys:
+        lines.append(f"{k} = {os.getenv(k, '')}")
+    try:
+        (run_dir / "run_config.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    except Exception as exc:
+        print(f"[WARN] Failed to write run_config.txt: {exc}")
+
+
+@dataclass
+class ExperimentConfig:
+    data_dir: Path
+    seed: int = 0
+    init_size: int = 200
+    acquisitions: int = 200
+    samples_per_acquisition: int = 20
+    epochs: int = 200
+    batch_size: int = 128
+    learning_rate: float = 1e-3
+    exploration_weight: float = 0.1
+    rollout_round: int = 50
+    ratio: float = 0.1
+    verbose: bool = False
+    turn: float = 0.1
+    nte_roots: int = 3
+    attenuate_late: bool = True
+
+
+def run_experiment(cfg: ExperimentConfig) -> None:
+    data_dir = cfg.data_dir
+
+    if not data_dir.exists():
+        raise FileNotFoundError(f"数据目录 {data_dir} 不存在")
+
+    x_train_raw, y_train_raw, x_test_raw, y_test_raw = _load_dataset(data_dir)
+
+    rosenbrock = Rosenbrock(dims=x_train_raw.shape[1], turn=cfg.turn)
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    run_dir = Path("rosenbrock20") / timestamp
+    run_dir.mkdir(parents=True, exist_ok=True)
+    rosenbrock.tracker.folder_name = str(run_dir)
+    Path(rosenbrock.tracker.folder_name).mkdir(parents=True, exist_ok=True)
+    print(f"[INFO] 本次运行的可视化输出目录：{run_dir}")
+
+    # 训练集与测试集都转换为 surrogate 需要的缩放目标
+    y_train_scaled = _scale_values(rosenbrock, y_train_raw)
+    y_test_scaled = _scale_values(rosenbrock, y_test_raw)
+
+    init_x = x_train_raw
+    init_y_scaled = y_train_scaled
+
+    # 更新 tracker，使得初始最优值与坐标立即可用
+    init_y_raw = []
+    for x_val in init_x:
+        raw_val = rosenbrock(x_val, apply_scaling=False, track=True)
+        init_y_raw.append(raw_val)
+    init_y_raw = np.array(init_y_raw, dtype=np.float32)
+    initial_best_idx = int(np.argmin(init_y_raw))
+    print(
+        "[INFO] 初始数据最优解: "
+        f"f(x) = {init_y_raw[initial_best_idx]:.6f}, "
+        f"x = {np.array2string(init_x[initial_best_idx], precision=4, separator=', ', suppress_small=True)}"
+    )
+
+    surrogate = RosenbrockSurrogateModel(
+        input_dims=init_x.shape[1],
+        epochs=cfg.epochs,
+        batch_size=cfg.batch_size,
+        learning_rate=cfg.learning_rate,
+    )
+    surrogate_plot_dir = run_dir / "surrogate_regression"
+    surrogate.plot_dir = surrogate_plot_dir
+    checkpoint_dir = Path.home() / ".cache" / "dante" / "checkpoints"
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    surrogate.check_point_path = checkpoint_dir / "rosenbrock20_best.keras"
+
+    tree_args = {
+        "exploration_weight": cfg.exploration_weight,
+        "rollout_round": cfg.rollout_round,
+        "ratio": cfg.ratio,
+        "root_points": cfg.nte_roots,
+        "attenuate_late": cfg.attenuate_late,
+    }
+    _write_run_config(run_dir, cfg, tree_args)
+
+    dal = DeepActiveLearning(
+        func=rosenbrock,
+        num_data_acquisition=cfg.acquisitions,
+        surrogate=surrogate,
+        tree_explorer_args=tree_args,
+        num_samples_per_acquisition=cfg.samples_per_acquisition,
+        num_init_samples=len(init_x),
+        input_x=init_x,
+        input_scaled_y=init_y_scaled,
+        input_raw_y=init_y_raw,
+    )
+
+    print(
+        f"[INFO] 启动优化：初始样本 {len(init_x)}（使用全部训练数据），"
+        f"计划新增 {cfg.acquisitions} 条，每轮获取 {cfg.samples_per_acquisition} 条。"
+    )
+    dal.run()
+
+    final_x = dal.input_x
+    final_scaled = dal.input_scaled_y
+    final_raw = np.array(
+        [rosenbrock(x, apply_scaling=False, track=False) for x in final_x],
+        dtype=np.float32,
+    )
+
+    best_idx = int(np.argmin(final_raw))
+    print(
+        "[RESULT] 当前最优："
+        f"f(x) = {final_raw[best_idx]:.6f}，"
+        f"scale = {final_scaled[best_idx]:.6f}，"
+        f"样本总数 {len(final_raw)}"
+    )
+
+    rosenbrock.tracker.dump_trace()
+
+    results = np.array(rosenbrock.tracker._results, dtype=np.float64)
+    if results.size:
+        np.save(run_dir / "best_trace.npy", results)
+        fig, ax = plt.subplots()
+        ax.plot(results)
+        ax.set_title("Best objective over iterations")
+        ax.set_xlabel("Iteration")
+        ax.set_ylabel("Best f(x)")
+        fig.savefig(run_dir / "best_trace.png", dpi=150, bbox_inches="tight")
+        plt.close(fig)
+
+    if final_x.size:
+        try:
+            initial_count = len(init_x)
+            offset = np.ones_like(final_x[:1])
+            tsne_input = final_x + offset if offset.size else final_x
+            perplexity = max(1, min(30, tsne_input.shape[0] - 1))
+            if tsne_input.shape[0] > 1 and perplexity > 0:
+                embedding = TSNE(
+                    n_components=2,
+                    learning_rate="auto",
+                    init="random",
+                    perplexity=perplexity,
+                ).fit_transform(tsne_input)
+                fig, ax = plt.subplots()
+                ax.scatter(
+                    embedding[:initial_count, 0],
+                    embedding[:initial_count, 1],
+                    s=6,
+                    c="tab:blue",
+                    label="Initial data",
+                )
+                if embedding.shape[0] > initial_count:
+                    ax.scatter(
+                        embedding[initial_count:, 0],
+                        embedding[initial_count:, 1],
+                        s=6,
+                        c="tab:red",
+                        label="Acquired data",
+                    )
+                best_idx = int(np.argmin(final_raw))
+                ax.scatter(
+                    embedding[best_idx, 0],
+                    embedding[best_idx, 1],
+                    marker="*",
+                    s=120,
+                    c="gold",
+                    label="Current best",
+                )
+                ax.set_title("t-SNE of sampled points")
+                ax.legend(loc="best")
+                fig.savefig(run_dir / "tsne_samples.png", dpi=150, bbox_inches="tight")
+                plt.close(fig)
+        except Exception as exc:
+            print(f"[WARN] Failed to generate t-SNE visualization: {exc}")
+
+    # 使用最终 surrogate 在离线测试集上评估表现
+    model = surrogate.model
+    if model is None:
+        print("[WARN] surrogate 尚未训练成功，跳过测试集评估。")
+        return
+
+    y_test_pred_scaled = model.predict(
+        x_test_raw.reshape(len(x_test_raw), init_x.shape[1], 1),
+        verbose=int(cfg.verbose),
+    ).reshape(-1)
+
+    r2 = r2_score(y_test_scaled, y_test_pred_scaled)
+    mae = mean_absolute_error(y_test_scaled, y_test_pred_scaled)
+    print(f"[TEST] Scaled 目标: R2={r2:.4f}, MAE={mae:.4f}")
+
+    # 将预测值反变换回原始目标，便于对比
+    epsilon = 1e-8
+    inv_pred_raw = rosenbrock.dims * 100 * (
+        100 / np.clip(y_test_pred_scaled, epsilon, None) - 0.01
+    )
+    print(
+        "[TEST] 原始目标: MAE="
+        f"{mean_absolute_error(y_test_raw, inv_pred_raw):.4f}"
+    )
+
+
+def parse_args() -> ExperimentConfig:
+    parser = argparse.ArgumentParser(description="优化 Rosenbrock-20d 数据集")
+    parser.add_argument("--data-dir", type=Path, default=Path("data_raw/Rosenbrock-20d"))
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--init-size", type=int, default=200)
+    parser.add_argument("--acquisitions", type=int, default=200)
+    parser.add_argument("--samples-per-acquisition", type=int, default=20)
+    parser.add_argument("--epochs", type=int, default=200)
+    parser.add_argument("--batch-size", type=int, default=128)
+    parser.add_argument("--learning-rate", type=float, default=1e-3)
+    parser.add_argument("--exploration-weight", type=float, default=0.1)
+    parser.add_argument("--rollout-round", type=int, default=50)
+    parser.add_argument("--ratio", type=float, default=0.1)
+    parser.add_argument("--turn", type=float, default=0.1)
+    parser.add_argument("--nte-roots", type=int, default=3, help="每轮用于 NTE 的根节点个数（默认 3）")
+    parser.add_argument("--no-late-attenuation", action="store_true", help="关闭每 100 轮后 20% 的探索权重衰减")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+    cfg_kwargs = vars(args)
+    cfg_kwargs["attenuate_late"] = not args.no_late_attenuation
+    # 删除仅用于切换的布尔参数，避免 dataclass 未知字段
+    del cfg_kwargs["no_late_attenuation"]
+    return ExperimentConfig(**cfg_kwargs)
+
+
+if __name__ == "__main__":
+    config = parse_args()
+    run_experiment(config)

--- a/experiments/rosenbrock_40d_opt.py
+++ b/experiments/rosenbrock_40d_opt.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python
+"""Active learning pipeline for Rosenbrock-40d using DANTE."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import faulthandler
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import List, Tuple
+import json
+
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn.manifold import TSNE
+from sklearn.metrics import mean_absolute_error, r2_score
+
+from dante.deep_active_learning import DeepActiveLearning
+from dante.neural_surrogate import RosenbrockSurrogateModel
+from dante.obj_functions import Rosenbrock
+
+
+try:
+    if not faulthandler.is_enabled():
+        faulthandler.enable()
+    faulthandler.register(signal.SIGUSR1, all_threads=True, chain=False)
+except Exception:
+    pass
+
+
+@dataclass
+class ExperimentConfig:
+    data_dir: Path
+    seed: int = 0
+    acquisitions: int = 600
+    samples_per_acquisition: int = 20
+    epochs: int = 400
+    batch_size: int = 128
+    learning_rate: float = 1e-3
+    exploration_weight: float = 0.1
+    rollout_round: int = 120
+    ratio: float = 0.1
+    verbose: bool = False
+    turn: float = 0.1
+    nte_roots: int = 3
+    attenuate_late: bool = True
+
+
+def _scale_values(func: Rosenbrock, y_raw: np.ndarray) -> np.ndarray:
+    return np.array([func.scaled(float(val)) for val in y_raw], dtype=np.float32)
+
+
+def _load_dataset(data_dir: Path) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    train = np.load(data_dir / "Rosenbrock-40d-train.npy")
+    test = np.load(data_dir / "Rosenbrock-40d-test.npy")
+    if train.ndim != 2 or test.ndim != 2 or train.shape[1] != test.shape[1]:
+        raise ValueError("Unexpected Rosenbrock-40d dataset format")
+    x_train = train[:, :-1].astype(np.float32)
+    y_train = train[:, -1].astype(np.float32)
+    x_test = test[:, :-1].astype(np.float32)
+    y_test = test[:, -1].astype(np.float32)
+    return x_train, y_train, x_test, y_test
+
+
+def _write_run_config(run_dir: Path, cfg: ExperimentConfig, tree_args: dict) -> None:
+    env_keys: List[str] = [
+        "OMP_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+        "TF_NUM_INTRAOP_THREADS",
+        "TF_NUM_INTEROP_THREADS",
+        "TF_FORCE_GPU_ALLOW_GROWTH",
+        "PYTHONFAULTHANDLER",
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD",
+        "PYTHONUNBUFFERED",
+        "DANTE_DEBUG_TIMING",
+        "CUDA_VISIBLE_DEVICES",
+    ]
+    lines: List[str] = []
+    lines.append("# DANTE run configuration\n")
+    lines.append(f"script = {Path(__file__).name}\n")
+    lines.append("[cli]")
+    for k, v in vars(cfg).items():
+        lines.append(f"{k} = {v}")
+    lines.append("")
+    lines.append("[tree_explorer_args]")
+    for k, v in tree_args.items():
+        lines.append(f"{k} = {v}")
+    lines.append("")
+    lines.append("[env]")
+    for k in env_keys:
+        lines.append(f"{k} = {os.getenv(k, '')}")
+    try:
+        (run_dir / "run_config.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    except Exception as exc:
+        print(f"[WARN] Failed to write run_config.txt: {exc}")
+
+
+def run_experiment(cfg: ExperimentConfig) -> None:
+    if not cfg.data_dir.exists():
+        raise FileNotFoundError(f"数据目录 {cfg.data_dir} 不存在")
+
+    x_train_raw, y_train_raw, x_test_raw, y_test_raw = _load_dataset(cfg.data_dir)
+    dims = x_train_raw.shape[1]
+    rosenbrock = Rosenbrock(dims=dims, turn=cfg.turn)
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    run_dir = Path("rosenbrock40") / timestamp
+    run_dir.mkdir(parents=True, exist_ok=True)
+    rosenbrock.tracker.folder_name = str(run_dir)
+    Path(rosenbrock.tracker.folder_name).mkdir(parents=True, exist_ok=True)
+    print(f"[INFO] 本次运行的可视化输出目录：{run_dir}")
+
+    y_train_scaled = _scale_values(rosenbrock, y_train_raw)
+    y_test_scaled = _scale_values(rosenbrock, y_test_raw)
+
+    init_x = x_train_raw
+    init_y_scaled = y_train_scaled
+
+    init_y_raw = np.array([rosenbrock(x, apply_scaling=False, track=True) for x in init_x], dtype=np.float32)
+    initial_best_idx = int(np.argmin(init_y_raw))
+    print(
+        "[INFO] 初始数据最优解: "
+        f"f(x) = {init_y_raw[initial_best_idx]:.6f}, "
+        f"x = {np.array2string(init_x[initial_best_idx], precision=4, separator=', ', suppress_small=True)}"
+    )
+
+    surrogate = RosenbrockSurrogateModel(
+        input_dims=init_x.shape[1],
+        epochs=cfg.epochs,
+        batch_size=cfg.batch_size,
+        learning_rate=cfg.learning_rate,
+    )
+    surrogate.plot_dir = run_dir / "surrogate_regression"
+    checkpoint_dir = Path.home() / ".cache" / "dante" / "checkpoints"
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    surrogate.check_point_path = checkpoint_dir / "rosenbrock40_best.keras"
+
+    tree_args = {
+        "exploration_weight": cfg.exploration_weight,
+        "rollout_round": cfg.rollout_round,
+        "ratio": cfg.ratio,
+        "root_points": cfg.nte_roots,
+        "attenuate_late": cfg.attenuate_late,
+    }
+    _write_run_config(run_dir, cfg, tree_args)
+
+    dal = DeepActiveLearning(
+        func=rosenbrock,
+        num_data_acquisition=cfg.acquisitions,
+        surrogate=surrogate,
+        tree_explorer_args=tree_args,
+        num_samples_per_acquisition=cfg.samples_per_acquisition,
+        num_init_samples=len(init_x),
+        input_x=init_x,
+        input_scaled_y=init_y_scaled,
+        input_raw_y=init_y_raw,
+    )
+
+    print(
+        f"[INFO] 启动优化：初始样本 {len(init_x)}，"
+        f"计划新增 {cfg.acquisitions} 条，每轮 {cfg.samples_per_acquisition} 条。"
+    )
+    dal.run()
+
+    final_x = dal.input_x
+    final_scaled = dal.input_scaled_y
+    final_raw = np.array([rosenbrock(x, apply_scaling=False, track=False) for x in final_x], dtype=np.float32)
+
+    best_idx = int(np.argmin(final_raw))
+    print(
+        "[RESULT] 当前最优："
+        f"f(x) = {final_raw[best_idx]:.6f}，"
+        f"scale = {final_scaled[best_idx]:.6f}，"
+        f"样本总数 {len(final_raw)}"
+    )
+
+    best_sample = {
+        "raw": float(final_raw[best_idx]),
+        "scaled": float(final_scaled[best_idx]),
+        "x": final_x[best_idx].astype(float).tolist(),
+    }
+    try:
+        (run_dir / "best_sample.json").write_text(
+            json.dumps(best_sample, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+    except Exception as exc:
+        print(f"[WARN] Failed to write best_sample.json: {exc}")
+
+    rosenbrock.tracker.dump_trace()
+
+    results = np.array(rosenbrock.tracker._results, dtype=np.float64)
+    if results.size:
+        np.save(run_dir / "best_trace.npy", results)
+        fig, ax = plt.subplots()
+        ax.plot(results)
+        ax.set_title("Best objective over iterations")
+        ax.set_xlabel("Iteration")
+        ax.set_ylabel("Best f(x)")
+        fig.savefig(run_dir / "best_trace.png", dpi=150, bbox_inches="tight")
+        plt.close(fig)
+
+    if final_x.size:
+        try:
+            initial_count = len(init_x)
+            offset = np.ones_like(final_x[:1])
+            tsne_input = final_x + offset if offset.size else final_x
+            perplexity = max(1, min(30, tsne_input.shape[0] - 1))
+            if tsne_input.shape[0] > 1 and perplexity > 0:
+                embedding = TSNE(
+                    n_components=2,
+                    learning_rate="auto",
+                    init="random",
+                    perplexity=perplexity,
+                ).fit_transform(tsne_input)
+                fig, ax = plt.subplots()
+                ax.scatter(
+                    embedding[:initial_count, 0],
+                    embedding[:initial_count, 1],
+                    s=6,
+                    c="tab:blue",
+                    label="Initial data",
+                )
+                if embedding.shape[0] > initial_count:
+                    ax.scatter(
+                        embedding[initial_count:, 0],
+                        embedding[initial_count:, 1],
+                        s=6,
+                        c="tab:red",
+                        label="Acquired data",
+                    )
+                best_idx = int(np.argmin(final_raw))
+                ax.scatter(
+                    embedding[best_idx, 0],
+                    embedding[best_idx, 1],
+                    marker="*",
+                    s=120,
+                    c="gold",
+                    label="Current best",
+                )
+                ax.set_title("t-SNE of sampled points")
+                ax.legend(loc="best")
+                fig.savefig(run_dir / "tsne_samples.png", dpi=150, bbox_inches="tight")
+                plt.close(fig)
+        except Exception as exc:
+            print(f"[WARN] Failed to generate t-SNE visualization: {exc}")
+
+    model = surrogate.model
+    if model is None:
+        print("[WARN] surrogate 尚未训练成功，跳过测试集评估。")
+        return
+
+    y_test_pred_scaled = model.predict(
+        x_test_raw.reshape(len(x_test_raw), dims, 1),
+        verbose=int(cfg.verbose),
+    ).reshape(-1)
+
+    r2 = r2_score(y_test_scaled, y_test_pred_scaled)
+    mae = mean_absolute_error(y_test_scaled, y_test_pred_scaled)
+    print(f"[TEST] Scaled 目标: R2={r2:.4f}, MAE={mae:.4f}")
+
+    epsilon = 1e-8
+    inv_pred_raw = rosenbrock.dims * 100 * (
+        100 / np.clip(y_test_pred_scaled, epsilon, None) - 0.01
+    )
+    print(
+        "[TEST] 原始目标: MAE="
+        f"{mean_absolute_error(y_test_raw, inv_pred_raw):.4f}"
+    )
+
+
+def parse_args() -> ExperimentConfig:
+    parser = argparse.ArgumentParser(description="优化 Rosenbrock-40d 数据集")
+    parser.add_argument("--data-dir", type=Path, default=Path("data_raw/Rosenbrock-40d"))
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--acquisitions", type=int, default=600)
+    parser.add_argument("--samples-per-acquisition", type=int, default=20)
+    parser.add_argument("--epochs", type=int, default=400)
+    parser.add_argument("--batch-size", type=int, default=128)
+    parser.add_argument("--learning-rate", type=float, default=1e-3)
+    parser.add_argument("--exploration-weight", type=float, default=0.1)
+    parser.add_argument("--rollout-round", type=int, default=120)
+    parser.add_argument("--ratio", type=float, default=0.1)
+    parser.add_argument("--turn", type=float, default=0.1)
+    parser.add_argument("--nte-roots", type=int, default=3, help="每轮用于 NTE 的根节点个数")
+    parser.add_argument("--no-late-attenuation", action="store_true", help="关闭每 100 轮后 20% 的探索权重衰减")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+    kwargs = vars(args)
+    kwargs["attenuate_late"] = not args.no_late_attenuation
+    del kwargs["no_late_attenuation"]
+    return ExperimentConfig(**kwargs)
+
+
+if __name__ == "__main__":
+    config = parse_args()
+    run_experiment(config)

--- a/experiments/schwefel_20d_opt.py
+++ b/experiments/schwefel_20d_opt.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python
+"""
+使用与 Rosenbrock-20d/Ackley-20d 相同的优化与可视化流程，对 data_raw/Schwefel-20d 进行主动优化。
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import faulthandler
+from datetime import datetime
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Tuple, List
+
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.metrics import mean_absolute_error, r2_score
+from sklearn.manifold import TSNE
+
+from dante.deep_active_learning import DeepActiveLearning
+from dante.neural_surrogate import SchwefelSurrogateModel
+from dante.obj_functions import Schwefel
+
+
+# Enable faulthandler and register SIGUSR1 to dump stacks without terminating.
+try:
+    if not faulthandler.is_enabled():
+        faulthandler.enable()
+    faulthandler.register(signal.SIGUSR1, all_threads=True, chain=False)
+except Exception:
+    pass
+
+
+def _scale_values(func: Schwefel, y_raw: np.ndarray) -> np.ndarray:
+    """将 Schwefel 原始目标值映射到最大化的缩放值。"""
+    return np.array([func.scaled(float(val)) for val in y_raw], dtype=np.float32)
+
+
+def _load_dataset(data_dir: Path) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    x_train = np.load(data_dir / "Schwefel_x_train.npy").astype(np.float32)
+    y_train = np.load(data_dir / "Schwefel_y_train.npy").astype(np.float32)
+    x_test = np.load(data_dir / "Schwefel_x_test.npy").astype(np.float32)
+    y_test = np.load(data_dir / "Schwefel_y_test.npy").astype(np.float32)
+    return x_train, y_train, x_test, y_test
+
+
+@dataclass
+class ExperimentConfig:
+    data_dir: Path
+    seed: int = 0
+    init_size: int = 200
+    acquisitions: int = 200
+    samples_per_acquisition: int = 20
+    epochs: int = 200
+    batch_size: int = 128
+    learning_rate: float = 1e-3
+    exploration_weight: float = 0.1
+    rollout_round: int = 50
+    ratio: float = 0.1
+    verbose: bool = False
+    turn: float = 1.0  # Schwefel 默认步长更大
+    nte_roots: int = 3
+    attenuate_late: bool = True
+
+
+def run_experiment(cfg: ExperimentConfig) -> None:
+    data_dir = cfg.data_dir
+    if not data_dir.exists():
+        raise FileNotFoundError(f"数据目录 {data_dir} 不存在")
+
+    x_train_raw, y_train_raw, x_test_raw, y_test_raw = _load_dataset(data_dir)
+
+    schwefel = Schwefel(dims=x_train_raw.shape[1], turn=cfg.turn)
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    run_dir = Path("schwefel20") / timestamp
+    run_dir.mkdir(parents=True, exist_ok=True)
+    schwefel.tracker.folder_name = str(run_dir)
+    Path(schwefel.tracker.folder_name).mkdir(parents=True, exist_ok=True)
+    print(f"[INFO] 本次运行的可视化输出目录：{run_dir}")
+
+    y_train_scaled = _scale_values(schwefel, y_train_raw)
+    y_test_scaled = _scale_values(schwefel, y_test_raw)
+
+    init_x = x_train_raw
+    init_y_scaled = y_train_scaled
+
+    # 初始化 tracker（使用真实目标值）
+    init_y_raw = []
+    for x_val in init_x:
+        raw_val = schwefel(x_val, apply_scaling=False, track=True)
+        init_y_raw.append(raw_val)
+    init_y_raw = np.array(init_y_raw, dtype=np.float32)
+    initial_best_idx = int(np.argmin(init_y_raw))
+    print(
+        "[INFO] 初始数据最优解: "
+        f"f(x) = {init_y_raw[initial_best_idx]:.6f}, "
+        f"x = {np.array2string(init_x[initial_best_idx], precision=4, separator=', ', suppress_small=True)}"
+    )
+
+    surrogate = SchwefelSurrogateModel(
+        input_dims=init_x.shape[1],
+        epochs=cfg.epochs,
+        batch_size=cfg.batch_size,
+        learning_rate=cfg.learning_rate,
+    )
+    surrogate_plot_dir = run_dir / "surrogate_regression"
+    surrogate.plot_dir = surrogate_plot_dir
+    checkpoint_dir = Path.home() / ".cache" / "dante" / "checkpoints"
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    surrogate.check_point_path = checkpoint_dir / "schwefel20_best.keras"
+
+    # save run configuration
+    tree_args = {
+        "exploration_weight": cfg.exploration_weight,
+        "rollout_round": cfg.rollout_round,
+        "ratio": cfg.ratio,
+        "root_points": cfg.nte_roots,
+        "attenuate_late": cfg.attenuate_late,
+    }
+    _write_run_config(run_dir, cfg, tree_args)
+
+    dal = DeepActiveLearning(
+        func=schwefel,
+        num_data_acquisition=cfg.acquisitions,
+        surrogate=surrogate,
+        tree_explorer_args=tree_args,
+        num_samples_per_acquisition=cfg.samples_per_acquisition,
+        num_init_samples=len(init_x),
+        input_x=init_x,
+        input_scaled_y=init_y_scaled,
+        input_raw_y=init_y_raw,
+    )
+
+    print(
+        f"[INFO] 启动优化：初始样本 {len(init_x)}（使用全部训练数据），"
+        f"计划新增 {cfg.acquisitions} 条，每轮获取 {cfg.samples_per_acquisition} 条。"
+    )
+    dal.run()
+
+    final_x = dal.input_x
+    final_scaled = dal.input_scaled_y
+    final_raw = np.array(
+        [schwefel(x, apply_scaling=False, track=False) for x in final_x],
+        dtype=np.float32,
+    )
+
+    best_idx = int(np.argmin(final_raw))
+    print(
+        "[RESULT] 当前最优："
+        f"f(x) = {final_raw[best_idx]:.6f}，"
+        f"scale = {final_scaled[best_idx]:.6f}，"
+        f"样本总数 {len(final_raw)}"
+    )
+
+    schwefel.tracker.dump_trace()
+
+    results = np.array(schwefel.tracker._results, dtype=np.float64)
+    if results.size:
+        np.save(run_dir / "best_trace.npy", results)
+        fig, ax = plt.subplots()
+        ax.plot(results)
+        ax.set_title("Best objective over iterations")
+        ax.set_xlabel("Iteration")
+        ax.set_ylabel("Best f(x)")
+        fig.savefig(run_dir / "best_trace.png", dpi=150, bbox_inches="tight")
+        plt.close(fig)
+
+    if final_x.size:
+        try:
+            initial_count = len(init_x)
+            offset = np.ones_like(final_x[:1])
+            tsne_input = final_x + offset if offset.size else final_x
+            perplexity = max(1, min(30, tsne_input.shape[0] - 1))
+            if tsne_input.shape[0] > 1 and perplexity > 0:
+                embedding = TSNE(
+                    n_components=2,
+                    learning_rate="auto",
+                    init="random",
+                    perplexity=perplexity,
+                ).fit_transform(tsne_input)
+                fig, ax = plt.subplots()
+                ax.scatter(
+                    embedding[:initial_count, 0],
+                    embedding[:initial_count, 1],
+                    s=6,
+                    c="tab:blue",
+                    label="Initial data",
+                )
+                if embedding.shape[0] > initial_count:
+                    ax.scatter(
+                        embedding[initial_count:, 0],
+                        embedding[initial_count:, 1],
+                        s=6,
+                        c="tab:red",
+                        label="Acquired data",
+                    )
+                best_idx = int(np.argmin(final_raw))
+                ax.scatter(
+                    embedding[best_idx, 0],
+                    embedding[best_idx, 1],
+                    marker="*",
+                    s=120,
+                    c="gold",
+                    label="Current best",
+                )
+                ax.set_title("t-SNE of sampled points")
+                ax.legend(loc="best")
+                fig.savefig(run_dir / "tsne_samples.png", dpi=150, bbox_inches="tight")
+                plt.close(fig)
+        except Exception as exc:
+            print(f"[WARN] Failed to generate t-SNE visualization: {exc}")
+
+    # 使用最终 surrogate 在离线测试集上评估表现
+    model = surrogate.model
+    if model is None:
+        print("[WARN] surrogate 尚未训练成功，跳过测试集评估。")
+        return
+
+    y_test_pred_scaled = model.predict(
+        x_test_raw.reshape(len(x_test_raw), init_x.shape[1], 1),
+        verbose=int(cfg.verbose),
+    ).reshape(-1)
+
+    r2 = r2_score(y_test_scaled, y_test_pred_scaled)
+    mae = mean_absolute_error(y_test_scaled, y_test_pred_scaled)
+    print(f"[TEST] Scaled 目标: R2={r2:.4f}, MAE={mae:.4f}")
+
+    # 反变换回原始目标：scaled = -y/100 (y!=0); 近似用 y = -100*scaled
+    inv_pred_raw = -100.0 * y_test_pred_scaled
+    print(
+        "[TEST] 原始目标: MAE="
+        f"{mean_absolute_error(y_test_raw, inv_pred_raw):.4f}"
+    )
+
+
+def _write_run_config(run_dir: Path, cfg: "ExperimentConfig", tree_args: dict) -> None:
+    env_keys: List[str] = [
+        "OMP_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+        "TF_NUM_INTRAOP_THREADS",
+        "TF_NUM_INTEROP_THREADS",
+        "TF_FORCE_GPU_ALLOW_GROWTH",
+        "PYTHONFAULTHANDLER",
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD",
+        "PYTHONUNBUFFERED",
+        "DANTE_DEBUG_TIMING",
+        "CUDA_VISIBLE_DEVICES",
+    ]
+    lines: List[str] = []
+    lines.append("# DANTE run configuration\n")
+    lines.append(f"script = {Path(__file__).name}\n")
+    lines.append("[cli]")
+    for k, v in vars(cfg).items():
+        lines.append(f"{k} = {v}")
+    lines.append("")
+    lines.append("[tree_explorer_args]")
+    for k, v in tree_args.items():
+        lines.append(f"{k} = {v}")
+    lines.append("")
+    lines.append("[env]")
+    for k in env_keys:
+        lines.append(f"{k} = {os.getenv(k, '')}")
+    try:
+        (run_dir / "run_config.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    except Exception as exc:
+        print(f"[WARN] Failed to write run_config.txt: {exc}")
+
+
+def parse_args() -> ExperimentConfig:
+    parser = argparse.ArgumentParser(description="优化 Schwefel-20d 数据集")
+    parser.add_argument("--data-dir", type=Path, default=Path("data_raw/Schwefel-20d"))
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--init-size", type=int, default=200)
+    parser.add_argument("--acquisitions", type=int, default=200)
+    parser.add_argument("--samples-per-acquisition", type=int, default=20)
+    parser.add_argument("--epochs", type=int, default=200)
+    parser.add_argument("--batch-size", type=int, default=128)
+    parser.add_argument("--learning-rate", type=float, default=1e-3)
+    parser.add_argument("--exploration-weight", type=float, default=0.1)
+    parser.add_argument("--rollout-round", type=int, default=50)
+    parser.add_argument("--ratio", type=float, default=0.1)
+    parser.add_argument("--turn", type=float, default=1.0)
+    parser.add_argument("--nte-roots", type=int, default=3, help="每轮用于 NTE 的根节点个数（默认 3）")
+    parser.add_argument("--no-late-attenuation", action="store_true", help="关闭每 100 轮后 20% 的探索权重衰减")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+    cfg_kwargs = vars(args)
+    cfg_kwargs["attenuate_late"] = not args.no_late_attenuation
+    del cfg_kwargs["no_late_attenuation"]
+    return ExperimentConfig(**cfg_kwargs)
+
+
+if __name__ == "__main__":
+    config = parse_args()
+    run_experiment(config)

--- a/experiments/schwefel_40d_opt.py
+++ b/experiments/schwefel_40d_opt.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python
+"""Active learning pipeline for Schwefel-40d using DANTE."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import faulthandler
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import List, Tuple
+import json
+
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn.manifold import TSNE
+from sklearn.metrics import mean_absolute_error, r2_score
+
+from dante.deep_active_learning import DeepActiveLearning
+from dante.neural_surrogate import SchwefelSurrogateModel
+from dante.obj_functions import Schwefel
+
+
+try:
+    if not faulthandler.is_enabled():
+        faulthandler.enable()
+    faulthandler.register(signal.SIGUSR1, all_threads=True, chain=False)
+except Exception:
+    pass
+
+
+@dataclass
+class ExperimentConfig:
+    data_dir: Path
+    seed: int = 0
+    acquisitions: int = 400
+    samples_per_acquisition: int = 20
+    epochs: int = 400
+    batch_size: int = 128
+    learning_rate: float = 1e-3
+    exploration_weight: float = 0.1
+    rollout_round: int = 120
+    ratio: float = 1.0
+    verbose: bool = False
+    turn: float = 1.0
+    nte_roots: int = 3
+    attenuate_late: bool = True
+
+
+def _load_dataset(data_dir: Path) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    train = np.load(data_dir / "Schwefel-40d-train.npy")
+    test = np.load(data_dir / "Schwefel-40d-test.npy")
+    if train.ndim != 2 or test.ndim != 2 or train.shape[1] != test.shape[1]:
+        raise ValueError("Unexpected Schwefel-40d dataset format")
+    x_train = train[:, :-1].astype(np.float32)
+    y_train = train[:, -1].astype(np.float32)
+    x_test = test[:, :-1].astype(np.float32)
+    y_test = test[:, -1].astype(np.float32)
+    return x_train, y_train, x_test, y_test
+
+
+def _scale_values(func: Schwefel, y_raw: np.ndarray) -> np.ndarray:
+    return np.array([func.scaled(float(val)) for val in y_raw], dtype=np.float32)
+
+
+def _write_run_config(run_dir: Path, cfg: ExperimentConfig, tree_args: dict) -> None:
+    env_keys: List[str] = [
+        "OMP_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+        "TF_NUM_INTRAOP_THREADS",
+        "TF_NUM_INTEROP_THREADS",
+        "TF_FORCE_GPU_ALLOW_GROWTH",
+        "PYTHONFAULTHANDLER",
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD",
+        "PYTHONUNBUFFERED",
+        "DANTE_DEBUG_TIMING",
+        "CUDA_VISIBLE_DEVICES",
+    ]
+    lines: List[str] = []
+    lines.append("# DANTE run configuration\n")
+    lines.append(f"script = {Path(__file__).name}\n")
+    lines.append("[cli]")
+    for k, v in vars(cfg).items():
+        lines.append(f"{k} = {v}")
+    lines.append("")
+    lines.append("[tree_explorer_args]")
+    for k, v in tree_args.items():
+        lines.append(f"{k} = {v}")
+    lines.append("")
+    lines.append("[env]")
+    for k in env_keys:
+        lines.append(f"{k} = {os.getenv(k, '')}")
+    try:
+        (run_dir / "run_config.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    except Exception as exc:
+        print(f"[WARN] Failed to write run_config.txt: {exc}")
+
+
+def run_experiment(cfg: ExperimentConfig) -> None:
+    if not cfg.data_dir.exists():
+        raise FileNotFoundError(f"数据目录 {cfg.data_dir} 不存在")
+
+    x_train_raw, y_train_raw, x_test_raw, y_test_raw = _load_dataset(cfg.data_dir)
+    dims = x_train_raw.shape[1]
+    schwefel = Schwefel(dims=dims, turn=cfg.turn)
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    run_dir = Path("schwefel40") / timestamp
+    run_dir.mkdir(parents=True, exist_ok=True)
+    schwefel.tracker.folder_name = str(run_dir)
+    Path(schwefel.tracker.folder_name).mkdir(parents=True, exist_ok=True)
+    print(f"[INFO] 本次运行的可视化输出目录：{run_dir}")
+
+    y_train_scaled = _scale_values(schwefel, y_train_raw)
+    y_test_scaled = _scale_values(schwefel, y_test_raw)
+
+    init_x = x_train_raw
+    init_y_scaled = y_train_scaled
+
+    init_y_raw = np.array([schwefel(x, apply_scaling=False, track=True) for x in init_x], dtype=np.float32)
+    initial_best_idx = int(np.argmin(init_y_raw))
+    print(
+        "[INFO] 初始数据最优解: "
+        f"f(x) = {init_y_raw[initial_best_idx]:.6f}, "
+        f"x = {np.array2string(init_x[initial_best_idx], precision=4, separator=', ', suppress_small=True)}"
+    )
+
+    surrogate = SchwefelSurrogateModel(
+        input_dims=dims,
+        epochs=cfg.epochs,
+        batch_size=cfg.batch_size,
+        learning_rate=cfg.learning_rate,
+    )
+    surrogate.plot_dir = run_dir / "surrogate_regression"
+    checkpoint_dir = Path.home() / ".cache" / "dante" / "checkpoints"
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    surrogate.check_point_path = checkpoint_dir / "schwefel40_best.keras"
+
+    tree_args = {
+        "exploration_weight": cfg.exploration_weight,
+        "rollout_round": cfg.rollout_round,
+        "ratio": cfg.ratio,
+        "root_points": cfg.nte_roots,
+        "attenuate_late": cfg.attenuate_late,
+    }
+    _write_run_config(run_dir, cfg, tree_args)
+
+    dal = DeepActiveLearning(
+        func=schwefel,
+        num_data_acquisition=cfg.acquisitions,
+        surrogate=surrogate,
+        tree_explorer_args=tree_args,
+        num_samples_per_acquisition=cfg.samples_per_acquisition,
+        num_init_samples=len(init_x),
+        input_x=init_x,
+        input_scaled_y=init_y_scaled,
+        input_raw_y=init_y_raw,
+    )
+
+    print(
+        f"[INFO] 启动优化：初始样本 {len(init_x)}，"
+        f"计划新增 {cfg.acquisitions} 条，每轮 {cfg.samples_per_acquisition} 条。"
+    )
+    dal.run()
+
+    final_x = dal.input_x
+    final_scaled = dal.input_scaled_y
+    final_raw = np.array([schwefel(x, apply_scaling=False, track=False) for x in final_x], dtype=np.float32)
+
+    best_idx = int(np.argmin(final_raw))
+    print(
+        "[RESULT] 当前最优："
+        f"f(x) = {final_raw[best_idx]:.6f}，"
+        f"scale = {final_scaled[best_idx]:.6f}，"
+        f"样本总数 {len(final_raw)}"
+    )
+
+    best_sample = {
+        "raw": float(final_raw[best_idx]),
+        "scaled": float(final_scaled[best_idx]),
+        "x": final_x[best_idx].astype(float).tolist(),
+    }
+    try:
+        (run_dir / "best_sample.json").write_text(
+            json.dumps(best_sample, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+    except Exception as exc:
+        print(f"[WARN] Failed to write best_sample.json: {exc}")
+
+    schwefel.tracker.dump_trace()
+
+    results = np.array(schwefel.tracker._results, dtype=np.float64)
+    if results.size:
+        np.save(run_dir / "best_trace.npy", results)
+        fig, ax = plt.subplots()
+        ax.plot(results)
+        ax.set_title("Best objective over iterations")
+        ax.set_xlabel("Iteration")
+        ax.set_ylabel("Best f(x)")
+        fig.savefig(run_dir / "best_trace.png", dpi=150, bbox_inches="tight")
+        plt.close(fig)
+
+    if final_x.size:
+        try:
+            initial_count = len(init_x)
+            offset = np.ones_like(final_x[:1])
+            tsne_input = final_x + offset if offset.size else final_x
+            perplexity = max(1, min(30, tsne_input.shape[0] - 1))
+            if tsne_input.shape[0] > 1 and perplexity > 0:
+                embedding = TSNE(
+                    n_components=2,
+                    learning_rate="auto",
+                    init="random",
+                    perplexity=perplexity,
+                ).fit_transform(tsne_input)
+                fig, ax = plt.subplots()
+                ax.scatter(
+                    embedding[:initial_count, 0],
+                    embedding[:initial_count, 1],
+                    s=6,
+                    c="tab:blue",
+                    label="Initial data",
+                )
+                if embedding.shape[0] > initial_count:
+                    ax.scatter(
+                        embedding[initial_count:, 0],
+                        embedding[initial_count:, 1],
+                        s=6,
+                        c="tab:red",
+                        label="Acquired data",
+                    )
+                best_idx = int(np.argmin(final_raw))
+                ax.scatter(
+                    embedding[best_idx, 0],
+                    embedding[best_idx, 1],
+                    marker="*",
+                    s=120,
+                    c="gold",
+                    label="Current best",
+                )
+                ax.set_title("t-SNE of sampled points")
+                ax.legend(loc="best")
+                fig.savefig(run_dir / "tsne_samples.png", dpi=150, bbox_inches="tight")
+                plt.close(fig)
+        except Exception as exc:
+            print(f"[WARN] Failed to generate t-SNE visualization: {exc}")
+
+    model = surrogate.model
+    if model is None:
+        print("[WARN] surrogate 尚未训练成功，跳过测试集评估。")
+        return
+
+    y_test_pred_scaled = model.predict(
+        x_test_raw.reshape(len(x_test_raw), dims, 1),
+        verbose=int(cfg.verbose),
+    ).reshape(-1)
+
+    r2 = r2_score(y_test_scaled, y_test_pred_scaled)
+    mae = mean_absolute_error(y_test_scaled, y_test_pred_scaled)
+    print(f"[TEST] Scaled 目标: R2={r2:.4f}, MAE={mae:.4f}")
+
+    inv_pred_raw = np.where(
+        np.isclose(y_test_pred_scaled, 10000.0),
+        0.0,
+        -100.0 * y_test_pred_scaled,
+    )
+    print(
+        "[TEST] 原始目标: MAE="
+        f"{mean_absolute_error(y_test_raw, inv_pred_raw):.4f}"
+    )
+
+
+def parse_args() -> ExperimentConfig:
+    parser = argparse.ArgumentParser(description="优化 Schwefel-40d 数据集")
+    parser.add_argument("--data-dir", type=Path, default=Path("data_raw/Schwefel-40d"))
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--acquisitions", type=int, default=400)
+    parser.add_argument("--samples-per-acquisition", type=int, default=20)
+    parser.add_argument("--epochs", type=int, default=400)
+    parser.add_argument("--batch-size", type=int, default=128)
+    parser.add_argument("--learning-rate", type=float, default=1e-3)
+    parser.add_argument("--exploration-weight", type=float, default=0.1)
+    parser.add_argument("--rollout-round", type=int, default=120)
+    parser.add_argument("--ratio", type=float, default=1.0)
+    parser.add_argument("--turn", type=float, default=1.0)
+    parser.add_argument("--nte-roots", type=int, default=3, help="每轮用于 NTE 的根节点个数")
+    parser.add_argument("--no-late-attenuation", action="store_true", help="关闭每 100 轮后 20% 的探索权重衰减")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+    kwargs = vars(args)
+    kwargs["attenuate_late"] = not args.no_late_attenuation
+    del kwargs["no_late_attenuation"]
+    return ExperimentConfig(**kwargs)
+
+
+if __name__ == "__main__":
+    config = parse_args()
+    run_experiment(config)

--- a/run_rosenbrock_then_schwefel.sh
+++ b/run_rosenbrock_then_schwefel.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export OMP_NUM_THREADS=6 MKL_NUM_THREADS=6 NUMEXPR_NUM_THREADS=6
+export TF_NUM_INTRAOP_THREADS=6 TF_NUM_INTEROP_THREADS=2
+export TF_FORCE_GPU_ALLOW_GROWTH=1
+export DANTE_DEBUG_TIMING=1 PYTHONFAULTHANDLER=1 PYTHONUNBUFFERED=1
+
+python -u experiments/rosenbrock_40d_opt.py \
+  --data-dir data_raw/Rosenbrock-40d \
+  --acquisitions 10000 \
+  --samples-per-acquisition 20 \
+  --epochs 500 \
+  --batch-size 128 \
+  --learning-rate 1e-3 \
+  --rollout-round 200 \
+  --ratio 0.8 \
+  --nte-roots 3 \
+  --turn 0.1 \
+  2>&1 | tee -a ~/rosenbrock40_train.log
+
+python -u experiments/schwefel_40d_opt.py \
+  --data-dir data_raw/Schwefel-40d \
+  --acquisitions 20000 \
+  --samples-per-acquisition 20 \
+  --epochs 500 \
+  --batch-size 128 \
+  --learning-rate 1e-3 \
+  --rollout-round 200 \
+  --ratio 1.0 \
+  --nte-roots 3 \
+  --turn 1.0 \
+  2>&1 | tee -a ~/schwefel40_train.log

--- a/tests/test_deep_active_learning.py
+++ b/tests/test_deep_active_learning.py
@@ -24,6 +24,7 @@ class TestDeepActiveLearning:
         assert dal_instance.num_samples_per_acquisition == 10
         assert dal_instance.input_x.shape == (10, 3)
         assert dal_instance.input_scaled_y.shape == (10,)
+        assert dal_instance.input_raw_y.shape == (10,)
 
     @pytest.mark.slow
     def test_run_method(self, dal_instance: DeepActiveLearning):
@@ -32,6 +33,7 @@ class TestDeepActiveLearning:
             dal_instance.input_x.shape[0] > 10
         )  # Should have more samples after running
         assert dal_instance.input_scaled_y.shape[0] > 10
+        assert dal_instance.input_raw_y.shape[0] > 10
 
     @pytest.mark.slow
     def test_different_objective_function(self):


### PR DESCRIPTION
- 候选样本去重与老样本过滤： np.concatenate 之后新增 _round_points → np.unique → _filter_unique，把同一坐标的候选合成一个，并剔除已经采过的点，解决“每轮选出的样本会重复” 的问题。 

- 排除选择阶段的 UCT 环： 原版 OptTask 将 (坐标, 预测值) 一起参与哈希/相等性判断，数值噪声会把同一坐标视为不同节点，推测会形成 A → B → C → A 的有向环。现将节点的 __hash__ / __eq__ 改为只依赖坐标，并在选择路径里维护 seen_tups，一旦遇到已出现的坐标就退回父节点，保证搜索结构始终是树形。

- 子节点生成只在本轮去重： 原逻辑把所有历史 children 都带入下一轮，每次生成子节点时都会从整个历史状态节点中进行比对。现在 _local_seen / _initial_visited 按轮更新，data_process、most_visit_node 都会过滤旧节点，只在本轮内判重；同时 _record_node 使用统一 rounding，防止浮点噪声导致的重复。
  